### PR TITLE
[REPO-02] Bootstrap trading-cli repo with CI and boundary guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run contract boundary tests
+        run: bun run ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # trading-cli
+
+External CLI client for Trade Nexus v2.
+
+## Gate0 bootstrap scope
+
+- CLI boundary guardrails only.
+- No direct provider API calls.
+- Platform API contract consumption only.
+
+## Local usage
+
+```bash
+bun test
+```
 Trade Nexus external CLI client consuming Platform API SDK

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "trading-cli",
+      "devDependencies": {
+        "@types/bun": "^1.2.20",
+        "typescript": "^5.9.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "trading-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Trade Nexus external CLI constrained to Platform API boundary",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "ci": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.20",
+    "typescript": "^5.9.2"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,61 @@
+const BLOCKED_PROVIDER_HOST_HINTS = [
+  "lona",
+  "live-engine",
+  "binance",
+  "alpaca",
+  "kraken",
+  "coinbase"
+] as const;
+
+export function assertPlatformApiBaseUrl(url: string): void {
+  const normalized = url.trim().toLowerCase();
+
+  if (!normalized) {
+    throw new Error("PLATFORM_API_BASE_URL is required.");
+  }
+
+  if (!/^https?:\/\//.test(normalized)) {
+    throw new Error("PLATFORM_API_BASE_URL must be an absolute http(s) URL.");
+  }
+
+  const isPlatformHost =
+    normalized.includes("api.trade-nexus.io") || normalized.includes("localhost");
+
+  const pointsToProvider = BLOCKED_PROVIDER_HOST_HINTS.some((hint) =>
+    normalized.includes(hint)
+  );
+
+  if (!isPlatformHost || pointsToProvider) {
+    throw new Error(
+      "Boundary violation: CLI must target Platform API only (no direct provider hosts)."
+    );
+  }
+}
+
+export function run(argv: string[]): number {
+  const baseUrl = process.env.PLATFORM_API_BASE_URL ?? "http://localhost:3000";
+  assertPlatformApiBaseUrl(baseUrl);
+
+  const args = argv.slice(2);
+  if (args.length === 0) {
+    console.log("trading-cli bootstrap: Platform API boundary checks enabled.");
+    return 0;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        status: "ok",
+        command: args,
+        target: baseUrl
+      },
+      null,
+      2
+    )
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(run(process.argv));
+}

--- a/tests/contract/platform-api-boundary.test.ts
+++ b/tests/contract/platform-api-boundary.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { assertPlatformApiBaseUrl } from "../../src/cli";
+
+describe("Platform API boundary", () => {
+  test("accepts platform API hosts", () => {
+    expect(() => assertPlatformApiBaseUrl("https://api.trade-nexus.io")).not.toThrow();
+    expect(() => assertPlatformApiBaseUrl("http://localhost:3000")).not.toThrow();
+  });
+
+  test("rejects direct provider hosts", () => {
+    expect(() => assertPlatformApiBaseUrl("https://gateway.lona.agency")).toThrow();
+    expect(() => assertPlatformApiBaseUrl("https://live-engine.internal")).toThrow();
+    expect(() => assertPlatformApiBaseUrl("https://api.binance.com")).toThrow();
+  });
+
+  test("declares provider-host guardrails in CLI source", () => {
+    const cliSource = readFileSync(resolve(process.cwd(), "src/cli.ts"), "utf-8");
+    expect(cliSource).toContain("BLOCKED_PROVIDER_HOST_HINTS");
+    expect(cliSource).toContain("Boundary violation");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary\n- bootstrap external trading-cli repository structure\n- add boundary guardrails to prevent direct provider API targeting\n- add contract-style boundary tests\n- add CI workflow with required check name \n\n## Testing\n- bun install\n- bun test\n\nFixes iamtxena/trade-nexus#18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New repo/bootstrap and test/CI additions with simple URL validation; low blast radius and no production data/auth flows impacted.
> 
> **Overview**
> Bootstraps the `trading-cli` repo with Bun/TypeScript tooling and a GitHub Actions CI workflow that runs `bun test` on PRs and pushes to `main`.
> 
> Adds a minimal CLI entrypoint (`src/cli.ts`) that enforces a **Platform API-only** boundary via `assertPlatformApiBaseUrl` (rejecting provider-like hosts), plus contract-style tests validating allowed/blocked URLs and asserting the guardrails exist in source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 636531ab77d0fcda5b907092e225f18f27559f6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->