### PR TITLE
fix: align CLI/SDK domain defaults to lona.agency hosts

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,9 +18,9 @@
 
 5. `REVIEW_WEB_BASE_URL` (optional)
    - Base URL used to build stable review-open links in CLI output.
-   - Default: `https://app.trade-nexus.io`.
+   - Default: `https://trade-nexus.lona.agency`.
 
 ## Defaults
 
 - Local Platform API default: `http://localhost:3000`
-- Review web default: `https://app.trade-nexus.io`
+- Review web default: `https://trade-nexus.lona.agency`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,8 @@ const BLOCKED_PROVIDER_HOST_HINTS = [
   "coinbase",
 ] as const;
 
+const PLATFORM_API_HOST = "api-nexus.lona.agency";
+
 const ALLOWED_LOCAL_LOOPBACK_HOSTS = new Set([
   "localhost",
   "127.0.0.1",
@@ -52,14 +54,13 @@ export function assertPlatformApiBaseUrl(url: string): void {
 
   const hostname = parsed.hostname.toLowerCase();
 
-  const isPlatformHost =
-    hostname === "api.trade-nexus.io" || ALLOWED_LOCAL_LOOPBACK_HOSTS.has(hostname);
+  const isPlatformHost = hostname === PLATFORM_API_HOST || ALLOWED_LOCAL_LOOPBACK_HOSTS.has(hostname);
 
   const pointsToProvider = BLOCKED_PROVIDER_HOST_HINTS.some((hint) =>
     hostname.includes(hint),
   );
 
-  if (pointsToProvider) {
+  if (pointsToProvider && !isPlatformHost) {
     throw new Error(
       "Boundary violation: CLI must target Platform API only (no direct provider hosts).",
     );
@@ -67,7 +68,7 @@ export function assertPlatformApiBaseUrl(url: string): void {
 
   if (!isPlatformHost) {
     throw new Error(
-      "PLATFORM_API_BASE_URL host must be api.trade-nexus.io or a local loopback host.",
+      "PLATFORM_API_BASE_URL host must be api-nexus.lona.agency or a local loopback host.",
     );
   }
 }

--- a/src/generated/trade-nexus-sdk/runtime.ts
+++ b/src/generated/trade-nexus-sdk/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "https://api.trade-nexus.io".replace(/\/+$/, "");
+export const BASE_PATH = "https://api-nexus.lona.agency".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/src/review-run-command.ts
+++ b/src/review-run-command.ts
@@ -17,7 +17,7 @@ import {
   type ValidationReviewRunSummary,
 } from "./generated/trade-nexus-sdk";
 
-const DEFAULT_REVIEW_WEB_BASE_URL = "https://app.trade-nexus.io";
+const DEFAULT_REVIEW_WEB_BASE_URL = "https://trade-nexus.lona.agency";
 const REVIEW_WEB_PATH = "/validation";
 
 const VALID_PROFILES = new Set<string>(Object.values(ValidationProfile));

--- a/tests/contract/platform-api-boundary.test.ts
+++ b/tests/contract/platform-api-boundary.test.ts
@@ -9,7 +9,7 @@ const SRC_ROOT = resolve(process.cwd(), "src");
 
 describe("Platform API boundary", () => {
   test("accepts platform API hosts", () => {
-    expect(() => assertPlatformApiBaseUrl("https://api.trade-nexus.io")).not.toThrow();
+    expect(() => assertPlatformApiBaseUrl("https://api-nexus.lona.agency")).not.toThrow();
     expect(() => assertPlatformApiBaseUrl("http://localhost:3000")).not.toThrow();
     expect(() => assertPlatformApiBaseUrl("http://127.0.0.1:3000")).not.toThrow();
     expect(() => assertPlatformApiBaseUrl("http://0.0.0.0:3000")).not.toThrow();
@@ -20,8 +20,8 @@ describe("Platform API boundary", () => {
     expect(() => assertPlatformApiBaseUrl("https://gateway.lona.agency")).toThrow();
     expect(() => assertPlatformApiBaseUrl("https://live-engine.internal")).toThrow();
     expect(() => assertPlatformApiBaseUrl("https://api.binance.com")).toThrow();
-    expect(() => assertPlatformApiBaseUrl("https://api.trade-nexus.io.evil.com")).toThrow();
-    expect(() => assertPlatformApiBaseUrl("https://evil.com/api.trade-nexus.io")).toThrow();
+    expect(() => assertPlatformApiBaseUrl("https://api-nexus.lona.agency.evil.com")).toThrow();
+    expect(() => assertPlatformApiBaseUrl("https://evil.com/api-nexus.lona.agency")).toThrow();
   });
 
   test("declares provider-host guardrails in CLI source", () => {

--- a/tests/smoke/review-run-cli.test.ts
+++ b/tests/smoke/review-run-cli.test.ts
@@ -40,7 +40,7 @@ describe("review-run command", () => {
 
     process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
     process.env.PLATFORM_API_BEARER_TOKEN = "token-test-123";
-    process.env.REVIEW_WEB_BASE_URL = "https://app.trade-nexus.io";
+    process.env.REVIEW_WEB_BASE_URL = "https://trade-nexus.lona.agency";
 
     console.log = (value: unknown) => {
       logs.push(String(value));
@@ -152,7 +152,7 @@ describe("review-run command", () => {
     expect(payload.status).toBe("ok");
     expect(payload.runId).toBe("valrun-20260220-0001");
     expect(payload.reviewWeb.path).toBe("/validation?runId=valrun-20260220-0001");
-    expect(payload.reviewWeb.url).toBe("https://app.trade-nexus.io/validation?runId=valrun-20260220-0001");
+    expect(payload.reviewWeb.url).toBe("https://trade-nexus.lona.agency/validation?runId=valrun-20260220-0001");
     expect(payload.renders.length).toBe(1);
     expect(payload.renders[0]?.pending).toBe(true);
   });
@@ -162,7 +162,7 @@ describe("review-run command", () => {
 
     process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
     process.env.PLATFORM_API_BEARER_TOKEN = "token-test-123";
-    process.env.REVIEW_WEB_BASE_URL = "https://review.trade-nexus.io";
+    process.env.REVIEW_WEB_BASE_URL = "https://review-nexus.lona.agency";
 
     console.log = (value: unknown) => {
       logs.push(String(value));
@@ -325,7 +325,7 @@ describe("review-run command", () => {
     expect(payload.summary.pendingDecision).toBe(true);
     expect(payload.reviewWeb.path).toBe("/validation?runId=valrun-20260220-0002");
     expect(payload.reviewWeb.url).toBe(
-      "https://review.trade-nexus.io/validation?runId=valrun-20260220-0002",
+      "https://review-nexus.lona.agency/validation?runId=valrun-20260220-0002",
     );
     expect(payload.render.pending).toBe(true);
   });


### PR DESCRIPTION
## Summary
- set canonical Platform API host guard to `api-nexus.lona.agency` while keeping loopback allowed and provider-host blocking intact
- set review-web default URL to `https://trade-nexus.lona.agency`
- align generated CLI SDK runtime base path to `https://api-nexus.lona.agency`
- update boundary/smoke tests and configuration docs to match new defaults
- harden boundary lint to allow canonical platform hosts on `lona.agency` while still flagging provider/exchange URLs

## Validation
- `bun run ci`
- `bun run test:consumer:mock`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily domain/default configuration changes plus stricter linting; behavior risk is limited to users relying on the old `trade-nexus.io` hostnames or edge-case URL matching.
> 
> **Overview**
> Aligns CLI, generated SDK, and docs to new canonical `lona.agency` endpoints: `PLATFORM_API_BASE_URL` is now validated against `api-nexus.lona.agency` (plus loopback), the SDK `BASE_PATH` default is updated accordingly, and review web link defaults move to `https://trade-nexus.lona.agency`.
> 
> Hardens boundary enforcement by updating `scripts/boundary-lint.ts` to scan all URL literals, allow known platform/loopback hosts, and still flag provider/exchange URLs; contract and smoke tests are updated to assert the new domains and expected generated review URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60ed2fefd110a3b572c8e3a6794926c4335581f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the CLI and SDK from `trade-nexus.io` to `lona.agency` domains, updating the canonical platform API host to `api-nexus.lona.agency` and review web to `trade-nexus.lona.agency`.

- Updated `PLATFORM_API_HOST` constant and error messages in `src/cli.ts`
- Modified boundary lint to explicitly allowlist canonical platform hosts while still blocking provider URLs
- Regenerated SDK with new `BASE_PATH` pointing to `api-nexus.lona.agency`
- Updated default review web URL and documentation
- Comprehensive test coverage updated to validate new domains and security boundaries

The changes are internally consistent and properly tested. All boundary validation logic correctly allows the new canonical hosts while maintaining security guardrails against direct provider access.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested domain migration with proper boundary enforcement
- All changes are coordinated configuration updates with comprehensive test coverage validating the new domain defaults and security boundaries
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CONFIGURATION.md | Updated documentation to reflect new `lona.agency` domain defaults |
| scripts/boundary-lint.ts | Hardened URL validation to scan all literals and explicitly allow canonical platform hosts |
| src/cli.ts | Updated platform API host constant to `api-nexus.lona.agency` with proper boundary checks |
| src/generated/trade-nexus-sdk/runtime.ts | Updated generated SDK base path to `https://api-nexus.lona.agency` |
| src/review-run-command.ts | Updated default review web URL to `https://trade-nexus.lona.agency` |
| tests/contract/platform-api-boundary.test.ts | Updated contract tests to validate new `api-nexus.lona.agency` host and security checks |
| tests/smoke/review-run-cli.test.ts | Updated smoke tests to assert new review web URLs with `lona.agency` domains |

</details>


</details>


<sub>Last reviewed commit: 60ed2fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->