### PR TITLE
feat(release): publish-readiness gates for trading-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,25 @@ jobs:
 
       - name: Run consumer mock contract tests
         run: bash scripts/run-mock-consumer-contract-tests.sh
+
+  publish-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate publish readiness
+        run: bash scripts/prepare-publish-release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Set to true to publish to npm. Default is dry-run."
+        required: false
+        default: "false"
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate semver/changelog/tag and package dry-run
+        run: bash scripts/prepare-publish-release.sh
+
+      - name: Publish package to npm
+        if: ${{ github.event_name == 'push' || inputs.publish == 'true' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
+        run: npm publish --access public
+
+      - name: Dry-run complete
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish != 'true' }}
+        run: echo "Dry-run complete. Set workflow input publish=true to publish to npm."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to `trading-cli` will be documented in this file.
+
+## v0.1.0
+
+- Initial external CLI release baseline.
+- Includes review-run and validation run commands via generated Platform API SDK.
+- Includes bot registration and key lifecycle commands.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -3,11 +3,27 @@
 ## Branching and merge
 
 1. Open PRs to `main`.
-2. Required status check: `ci`.
+2. Required status checks: `checks`, `mock-consumer-contract`, and `publish-validation`.
 3. At least one approving review is required by branch protection.
 
 ## Release baseline
 
-1. Update changelog/release notes in PR description.
-2. Confirm boundary tests are passing.
-3. Tag release after merge using semantic versioning.
+1. Update `CHANGELOG.md` with a heading matching `package.json` version (for example `## v0.2.0`).
+2. Confirm CI is green, including publish validation.
+3. Tag release after merge using semantic versioning (`v<package-version>`).
+
+## GitHub release workflow
+
+- Workflow file: `.github/workflows/release.yml`
+- Triggers:
+1. Manual dispatch (`publish=false` by default) runs a dry-run release.
+2. `push` on tags matching `v*` runs release checks and publishes.
+- Release checks:
+1. Version is semver-compatible.
+2. `CHANGELOG.md` has an entry for the current package version.
+3. Tag/version alignment (`v<package-version>`) on tag-triggered runs.
+4. Build and `npm pack --dry-run --ignore-scripts`.
+
+## npm publish secrets (names only)
+
+- `NPM_TOKEN` (npm automation token used as `NODE_AUTH_TOKEN` in release workflow)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "files": [
     "dist",
+    "CHANGELOG.md",
     "README.md",
     "LICENSE",
     "COMMAND_REFERENCE.md",
@@ -20,6 +21,10 @@
   ],
   "bin": {
     "trading-cli": "dist/cli.js"
+  },
+  "exports": {
+    ".": "./dist/cli.js",
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"
@@ -32,6 +37,7 @@
     "test:consumer:mock": "bash scripts/run-mock-consumer-contract-tests.sh",
     "lint": "bun run scripts/boundary-lint.ts",
     "typecheck": "tsc --noEmit",
+    "release:check": "bash scripts/prepare-publish-release.sh",
     "ci": "bun run lint && bun run typecheck && bun test"
   },
   "devDependencies": {

--- a/scripts/prepare-publish-release.sh
+++ b/scripts/prepare-publish-release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_JSON_PATH="${REPO_ROOT}/package.json"
+CHANGELOG_PATH="${REPO_ROOT}/CHANGELOG.md"
+
+PACKAGE_VERSION="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(p.version);" "${PACKAGE_JSON_PATH}")"
+PACKAGE_PRIVATE="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(String(Boolean(p.private)));" "${PACKAGE_JSON_PATH}")"
+
+if [[ ! "${PACKAGE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "package.json version is not semver-compatible: ${PACKAGE_VERSION}" >&2
+  exit 1
+fi
+
+if [[ "${PACKAGE_PRIVATE}" != "false" ]]; then
+  echo "package.json must set private=false before publishing." >&2
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (!pkg.exports || typeof pkg.exports !== "object") {
+  console.error("package.json exports field is required.");
+  process.exit(1);
+}
+if (pkg.exports["."] !== "./dist/cli.js") {
+  console.error("package.json exports['.'] must point to ./dist/cli.js.");
+  process.exit(1);
+}
+' "${PACKAGE_JSON_PATH}"
+
+if [[ ! -f "${CHANGELOG_PATH}" ]]; then
+  echo "Missing CHANGELOG.md. Add a release entry for version ${PACKAGE_VERSION}." >&2
+  exit 1
+fi
+
+if ! grep -Eq "^##[[:space:]]+\[?v?${PACKAGE_VERSION}\]?" "${CHANGELOG_PATH}"; then
+  echo "CHANGELOG.md is missing a heading for version ${PACKAGE_VERSION}." >&2
+  exit 1
+fi
+
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  EXPECTED_TAG="v${PACKAGE_VERSION}"
+  if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]]; then
+    echo "Tag mismatch: expected ${EXPECTED_TAG}, got ${GITHUB_REF_NAME}" >&2
+    exit 1
+  fi
+fi
+
+pushd "${REPO_ROOT}" >/dev/null
+bun run build
+npm pack --dry-run --ignore-scripts >/dev/null
+popd >/dev/null
+
+echo "Publish release checks passed for version ${PACKAGE_VERSION}."

--- a/tests/smoke/package-smoke.test.ts
+++ b/tests/smoke/package-smoke.test.ts
@@ -61,12 +61,15 @@ describe("packaging smoke", () => {
     const packageJson = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8")) as {
       private?: boolean;
       bin?: Record<string, string>;
+      exports?: Record<string, string>;
       scripts?: Record<string, string>;
       publishConfig?: Record<string, string>;
     };
 
     expect(packageJson.private).toBe(false);
     expect(packageJson.bin?.["trading-cli"]).toBe("dist/cli.js");
+    expect(packageJson.exports?.["."]).toBe("./dist/cli.js");
+    expect(packageJson.exports?.["./package.json"]).toBe("./package.json");
     expect(packageJson.scripts?.build).toContain("bun build");
     expect(packageJson.publishConfig?.access).toBe("public");
   });


### PR DESCRIPTION
## Summary
- add explicit package `exports` and include `CHANGELOG.md` in published artifacts
- add a dedicated release workflow (`.github/workflows/release.yml`) with semver/tag/changelog validation and npm dry-run/publish flow
- add CI `publish-validation` checks via `scripts/prepare-publish-release.sh`
- document release gates and npm publish secret names in `RELEASE_PROCESS.md`

## Validation
- `bun run ci`
- `bun run release:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI/release automation and adds an npm publish path; misconfiguration could block releases or publish incorrect artifacts, though no runtime CLI logic is modified.
> 
> **Overview**
> Adds **publish-readiness validation** to CI via a new `publish-validation` job that runs `scripts/prepare-publish-release.sh`.
> 
> Introduces a new GitHub Actions `release` workflow that performs version/changelog/tag checks plus `npm pack --dry-run`, and conditionally runs `npm publish` on `v*` tags or manual dispatch with `publish=true`.
> 
> Tightens package publish metadata by adding explicit `exports`, including `CHANGELOG.md` in published files, adding `release:check`, and updating smoke tests/docs to enforce and describe the new release gates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8d4ef4fcfadaa3a6638500073eacef53ca2efe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds publish-readiness gates for `trading-cli`: a new `publish-validation` CI job, a dedicated `release.yml` workflow for semver/changelog/tag validation and npm publish, explicit `exports` in `package.json`, and supporting documentation. The changes are well-structured overall, but the validation script contains two correctness issues that could silently let a misconfigured package through.

- **Logic bug** in `prepare-publish-release.sh`: the `private` field check uses `Boolean(p.private)`, which evaluates `undefined` (field not set) as `"false"` — the same result as an explicit `private: false`. A package missing the field would pass the guard.
- **Unescaped dots** in the CHANGELOG `grep` pattern: `${PACKAGE_VERSION}` is embedded as-is into an ERE pattern, where `.` is a wildcard; a version like `0.1.0` would match `0X1Y0`.
- **Publish condition** in `release.yml` uses `github.event_name == 'push'` without additionally asserting `startsWith(github.ref, 'refs/tags/v')`, relying entirely on the workflow trigger filter — which is correct today but fragile to future edits.
- **Double build**: `prepare-publish-release.sh` calls `bun run build` explicitly, and `npm publish` (no `--ignore-scripts`) then fires `prepack`, which runs the build a second time.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution — no runtime CLI logic is changed, but two validation bugs in the release script could silently pass a misconfigured package.
- The core CLI is untouched and the publish infrastructure is largely correct. However, the `private` field logic bug and the unescaped-dots grep issue mean the gating script is weaker than intended, which could let a misconfigured package reach npm without the intended safety checks firing.
- `scripts/prepare-publish-release.sh` and `.github/workflows/release.yml` need attention for the logic issues identified.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/prepare-publish-release.sh | New script that validates semver, private flag, exports, changelog, and tag alignment before running a dry-run pack. Contains a logic bug in the `private` check (falsy vs. strict equality) and unescaped dots in the CHANGELOG grep pattern. |
| .github/workflows/release.yml | New release workflow that validates and publishes to npm. The publish condition uses a broad `github.event_name == 'push'` check instead of verifying the tag ref, and the build runs twice (once in prepare-publish-release.sh and again via npm prepack). |
| .github/workflows/ci.yml | Adds a new `publish-validation` job that runs `prepare-publish-release.sh` as a required CI check. Setup mirrors the existing jobs and is straightforward. |
| package.json | Adds `exports` map, includes `CHANGELOG.md` in published files, and adds a `release:check` script. Changes are correct and consistent with the rest of the PR. |
| tests/smoke/package-smoke.test.ts | Extends packaging smoke tests to assert the new `exports` map entries. Changes are accurate and match the `package.json` values. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant Script as prepare-publish-release.sh
    participant NPM as npm registry

    Dev->>GH: Push v* tag (or manual dispatch)
    GH->>Script: bash scripts/prepare-publish-release.sh
    Script->>Script: Check semver (package.json version)
    Script->>Script: Check private !== true
    Script->>Script: Check exports["."] == ./dist/cli.js
    Script->>Script: Check CHANGELOG.md has version heading
    Script->>Script: Check tag == v{version} (tag runs only)
    Script->>Script: bun run build
    Script->>Script: npm pack --dry-run --ignore-scripts
    Script-->>GH: Checks passed
    alt publish == true OR event == push (tag)
        GH->>GH: npm publish (triggers prepack → bun run build again)
        GH->>NPM: Publish package
    else dry-run
        GH->>GH: Echo "Dry-run complete"
    end
```

<sub>Last reviewed commit: f8d4ef4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->