### PR TITLE
feat(core): phase2 parity for external command groups

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { formatReviewRunError, runReviewRunCommand } from "./review-run-command";
 import { runValidationBotCommand } from "./validation-bot-command";
+import { runCoreCommand } from "./core-command";
 
 const BLOCKED_PROVIDER_HOST_HINTS = [
   "lona",
@@ -106,6 +107,12 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
         "register partner",
         "key rotate",
         "key revoke",
+        "research scan",
+        "strategy create|get|list|update",
+        "backtest create|get",
+        "deploy create|get|list|stop",
+        "portfolio list|get",
+        "order create|get|list|cancel",
       ],
     });
     return 0;
@@ -139,9 +146,24 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
       return 0;
     }
 
+    if (
+      args[0] === "research" ||
+      args[0] === "strategy" ||
+      args[0] === "backtest" ||
+      args[0] === "deploy" ||
+      args[0] === "portfolio" ||
+      args[0] === "order"
+    ) {
+      await runCoreCommand(args, context);
+      return 0;
+    }
+
     emitError({
       status: "error",
-      message: `Unknown command '${args[0]}'. Use 'review-run', 'validation run', 'register', 'key', or 'bot'.`,
+      message:
+        `Unknown command '${args[0]}'. Use 'review-run', 'validation run', ` +
+        "'register', 'key', 'bot', 'research', 'strategy', 'backtest', " +
+        "'deploy', 'portfolio', or 'order'.",
       command: args,
       target: baseUrl,
     });

--- a/src/command-utils.ts
+++ b/src/command-utils.ts
@@ -8,6 +8,10 @@ export type CommandContext = {
   emit: (payload: unknown) => void;
 };
 
+export type OutputMode = "json" | "table";
+export type TableCell = string | number | boolean | null | undefined;
+export type TableRow = Record<string, TableCell>;
+
 export function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
 }
@@ -42,4 +46,66 @@ export function deriveIdempotencyKey(prefix: string, seed?: string): string {
     return seed;
   }
   return `${prefix}-${randomUUID()}`;
+}
+
+export function parseOutputMode(value: unknown): OutputMode {
+  const normalized = nonEmpty(value)?.toLowerCase();
+  if (!normalized || normalized === "json") {
+    return "json";
+  }
+  if (normalized === "table") {
+    return "table";
+  }
+  throw new Error("Unsupported --output value. Use 'json' or 'table'.");
+}
+
+export function toSerializable(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toSerializable(item));
+  }
+
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = toSerializable(item);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+function stringifyTableCell(value: TableCell): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  return String(value);
+}
+
+export function formatTable(rows: TableRow[], columns: string[]): string {
+  if (rows.length === 0) {
+    return "(no rows)";
+  }
+
+  const widths = columns.map((column) =>
+    Math.max(column.length, ...rows.map((row) => stringifyTableCell(row[column]).length)),
+  );
+
+  const renderLine = (values: string[]) =>
+    values.map((value, index) => value.padEnd(widths[index] ?? value.length)).join(" | ");
+
+  const header = renderLine(columns);
+  const separator = widths.map((width) => "-".repeat(width)).join("-+-");
+  const body = rows
+    .map((row) => renderLine(columns.map((column) => stringifyTableCell(row[column]))))
+    .join("\n");
+
+  return `${header}\n${separator}\n${body}`;
 }

--- a/src/core-command.ts
+++ b/src/core-command.ts
@@ -1,0 +1,1202 @@
+import { parseArgs } from "node:util";
+
+import {
+  type CommandContext,
+  deriveIdempotencyKey,
+  deriveRequestId,
+  formatTable,
+  nonEmpty,
+  parseJsonFile,
+  parseOutputMode,
+  toSerializable,
+  type OutputMode,
+  type TableRow,
+} from "./command-utils";
+import {
+  DeploymentStatus,
+  OrderStatus,
+  StrategyStatus,
+  type CreateBacktestRequest,
+  type CreateDeploymentRequest,
+  type CreateOrderRequest,
+  type CreateStrategyRequest,
+  type MarketScanRequest,
+  type UpdateStrategyRequest,
+} from "./generated/trade-nexus-sdk";
+import {
+  createBacktestsApiClient,
+  createDeploymentsApiClient,
+  createOrdersApiClient,
+  createPortfoliosApiClient,
+  createResearchApiClient,
+  createStrategiesApiClient,
+} from "./platform-api-sdk";
+
+type ParsedValues = ReturnType<typeof parseArgs>["values"];
+type TableOutput = {
+  title?: string;
+  rows: TableRow[];
+  columns: string[];
+  emptyMessage?: string;
+  notes?: string[];
+};
+
+const CORE_REQUEST_ID_PREFIX = "req-core";
+const CORE_IDEMPOTENCY_KEY_PREFIX = "idem-core";
+
+const STRATEGY_STATUSES = new Set<string>(Object.values(StrategyStatus));
+const DEPLOYMENT_STATUSES = new Set<string>(Object.values(DeploymentStatus));
+const ORDER_STATUSES = new Set<string>(Object.values(OrderStatus));
+
+function parseCsv(value: unknown): string[] {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function parseNumeric(value: unknown, label: string): number {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    throw new Error(`${label} is required.`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${label} must be a valid number.`);
+  }
+  return parsed;
+}
+
+function parseOptionalDate(value: unknown, label: string): Date | undefined {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be a valid ISO date.`);
+  }
+  return parsed;
+}
+
+function parseRequiredDate(value: unknown, label: string): Date {
+  const parsed = parseOptionalDate(value, label);
+  if (!parsed) {
+    throw new Error(`${label} is required.`);
+  }
+  return parsed;
+}
+
+function parseEnumValue<T extends string>(
+  value: unknown,
+  label: string,
+  allowed: Set<string>,
+): T | undefined {
+  const raw = nonEmpty(value)?.toLowerCase();
+  if (!raw) {
+    return undefined;
+  }
+  if (!allowed.has(raw)) {
+    throw new Error(`${label} must be one of: ${Array.from(allowed).join(", ")}.`);
+  }
+  return raw as T;
+}
+
+function parseRequestId(values: ParsedValues): string {
+  return deriveRequestId(CORE_REQUEST_ID_PREFIX, nonEmpty(values["request-id"]));
+}
+
+function parseIdempotencyKey(values: ParsedValues): string {
+  return deriveIdempotencyKey(CORE_IDEMPOTENCY_KEY_PREFIX, nonEmpty(values["idempotency-key"]));
+}
+
+function emitOutput(
+  context: CommandContext,
+  output: OutputMode,
+  payload: unknown,
+  table?: TableOutput,
+): void {
+  const normalizedPayload = toSerializable(payload);
+
+  if (output === "json") {
+    context.emit(normalizedPayload);
+    return;
+  }
+
+  if (!table) {
+    console.log(JSON.stringify(normalizedPayload, null, 2));
+    return;
+  }
+
+  const lines: string[] = [];
+  if (table.title) {
+    lines.push(table.title);
+  }
+  if (table.notes && table.notes.length > 0) {
+    lines.push(...table.notes);
+  }
+  if (table.rows.length === 0) {
+    lines.push(table.emptyMessage ?? "(no rows)");
+  } else {
+    lines.push(formatTable(table.rows, table.columns));
+  }
+  console.log(lines.join("\n"));
+}
+
+function toStrategyTableRow(strategy: Record<string, unknown>): TableRow {
+  return {
+    id: strategy.id as string,
+    name: strategy.name as string,
+    status: strategy.status as string,
+    provider: strategy.provider as string,
+    createdAt: strategy.createdAt as string,
+  };
+}
+
+function toDeploymentTableRow(deployment: Record<string, unknown>): TableRow {
+  return {
+    id: deployment.id as string,
+    strategyId: deployment.strategyId as string,
+    mode: deployment.mode as string,
+    status: deployment.status as string,
+    capital: deployment.capital as number,
+    latestPnl: deployment.latestPnl as number | null | undefined,
+  };
+}
+
+function toOrderTableRow(order: Record<string, unknown>): TableRow {
+  return {
+    id: order.id as string,
+    symbol: order.symbol as string,
+    side: order.side as string,
+    type: order.type as string,
+    quantity: order.quantity as number,
+    status: order.status as string,
+    createdAt: order.createdAt as string,
+  };
+}
+
+function toPortfolioTableRow(portfolio: Record<string, unknown>): TableRow {
+  const positions = portfolio.positions as unknown[];
+  return {
+    id: portfolio.id as string,
+    mode: portfolio.mode as string,
+    cash: portfolio.cash as number,
+    totalValue: portfolio.totalValue as number,
+    pnlTotal: portfolio.pnlTotal as number | undefined,
+    positions: Array.isArray(positions) ? positions.length : 0,
+  };
+}
+
+function parseMarketScanRequest(values: ParsedValues): MarketScanRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<MarketScanRequest>(inputPath, "research scan payload");
+  }
+
+  const assetClasses = parseCsv(values["asset-classes"]);
+  if (assetClasses.length === 0) {
+    throw new Error("--asset-classes is required when --input is not provided.");
+  }
+
+  const capital = parseNumeric(values.capital, "--capital");
+
+  const constraintsRaw = nonEmpty(values["constraints-json"]);
+  let constraints: Record<string, unknown> | undefined;
+  if (constraintsRaw) {
+    try {
+      const parsed = JSON.parse(constraintsRaw) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("must be a JSON object");
+      }
+      constraints = parsed as Record<string, unknown>;
+    } catch (error) {
+      throw new Error(
+        `Unable to parse --constraints-json: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return {
+    assetClasses: assetClasses as MarketScanRequest["assetClasses"],
+    capital,
+    constraints: constraints as MarketScanRequest["constraints"],
+  };
+}
+
+async function runResearchCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    context.emit({
+      status: "ok",
+      command: "research",
+      usage: [
+        "trading-cli research scan --input <market-scan.json> [--version v2] [--output json|table]",
+        "trading-cli research scan --asset-classes crypto,stocks --capital 50000 [--version v2] [--output json|table]",
+      ],
+    });
+    return;
+  }
+
+  if (subcommand !== "scan") {
+    throw new Error(`Unknown research subcommand '${subcommand}'. Use 'scan'.`);
+  }
+
+  const parsed = parseArgs({
+    args: args.slice(1),
+    options: {
+      input: { type: "string" },
+      version: { type: "string" },
+      "asset-classes": { type: "string" },
+      capital: { type: "string" },
+      "constraints-json": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const version = nonEmpty(parsed.values.version)?.toLowerCase() ?? "v2";
+  if (version !== "v1" && version !== "v2") {
+    throw new Error("--version must be 'v1' or 'v2'.");
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const requestId = parseRequestId(parsed.values);
+  const payload = parseMarketScanRequest(parsed.values);
+  const api = createResearchApiClient(context);
+
+  const response =
+    version === "v1"
+      ? await api.postMarketScanV1({ marketScanRequest: payload, xRequestId: requestId })
+      : await api.postMarketScanV2({ marketScanRequest: payload, xRequestId: requestId });
+
+  const body = {
+    status: "ok",
+    command: "research scan",
+    version,
+    requestId: response.requestId,
+    regimeSummary: response.regimeSummary,
+    strategyIdeas: response.strategyIdeas,
+    ...(version === "v2"
+      ? {
+          knowledgeEvidence: (response as { knowledgeEvidence?: unknown[] }).knowledgeEvidence ?? [],
+          dataContextSummary: (response as { dataContextSummary?: string }).dataContextSummary ?? null,
+        }
+      : {}),
+  };
+
+  emitOutput(context, output, body, {
+    title: "research scan",
+    notes: [`requestId: ${response.requestId}`, `regime: ${response.regimeSummary}`],
+    rows: response.strategyIdeas.map((idea) => ({
+      name: idea.name,
+      assetClass: idea.assetClass,
+      description: idea.description,
+    })),
+    columns: ["name", "assetClass", "description"],
+    emptyMessage: "No strategy ideas returned.",
+  });
+}
+
+function parseCreateStrategyRequest(values: ParsedValues): CreateStrategyRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateStrategyRequest>(inputPath, "strategy create payload");
+  }
+
+  const description = nonEmpty(values.description);
+  if (!description) {
+    throw new Error("--description is required when --input is not provided.");
+  }
+
+  const name = nonEmpty(values.name);
+  const provider = nonEmpty(values.provider);
+  return {
+    description,
+    ...(name ? { name } : {}),
+    ...(provider ? { provider: provider as CreateStrategyRequest["provider"] } : {}),
+  };
+}
+
+function parseUpdateStrategyRequest(values: ParsedValues): UpdateStrategyRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<UpdateStrategyRequest>(inputPath, "strategy update payload");
+  }
+
+  const status = parseEnumValue<StrategyStatus>(
+    values.status,
+    "--status",
+    STRATEGY_STATUSES,
+  ) as StrategyStatus | undefined;
+  const payload: UpdateStrategyRequest = {};
+  const name = nonEmpty(values.name);
+  const description = nonEmpty(values.description);
+  const tags = parseCsv(values.tags);
+
+  if (name) {
+    payload.name = name;
+  }
+  if (description) {
+    payload.description = description;
+  }
+  if (status) {
+    payload.status = status;
+  }
+  if (tags.length > 0) {
+    payload.tags = tags;
+  }
+
+  if (Object.keys(payload).length === 0) {
+    throw new Error(
+      "Provide at least one updatable field (--name, --description, --status, --tags) or --input.",
+    );
+  }
+
+  return payload;
+}
+
+async function runStrategyCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    context.emit({
+      status: "ok",
+      command: "strategy",
+      usage: [
+        "trading-cli strategy create --description \"Momentum breakout\" [--name <name>] [--output json|table]",
+        "trading-cli strategy create --input <create-strategy.json> [--output json|table]",
+        "trading-cli strategy get --strategy-id <id> [--output json|table]",
+        "trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--output json|table]",
+        "trading-cli strategy update --strategy-id <id> --status deployable [--output json|table]",
+      ],
+    });
+    return;
+  }
+
+  const api = createStrategiesApiClient(context);
+
+  if (subcommand === "create") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        input: { type: "string" },
+        name: { type: "string" },
+        description: { type: "string" },
+        provider: { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.createStrategyV1({
+      createStrategyRequest: parseCreateStrategyRequest(parsed.values),
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const strategy = serial.strategy as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "strategy create", ...serial },
+      {
+        title: "strategy create",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toStrategyTableRow(strategy)],
+        columns: ["id", "name", "status", "provider", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "get") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "strategy-id": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const strategyId = nonEmpty(parsed.values["strategy-id"]);
+    if (!strategyId) {
+      throw new Error("--strategy-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.getStrategyV1({
+      strategyId,
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const strategy = serial.strategy as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "strategy get", ...serial },
+      {
+        title: "strategy get",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toStrategyTableRow(strategy)],
+        columns: ["id", "name", "status", "provider", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "list") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        status: { type: "string" },
+        cursor: { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const output = parseOutputMode(parsed.values.output);
+    const status = parseEnumValue<StrategyStatus>(
+      parsed.values.status,
+      "--status",
+      STRATEGY_STATUSES,
+    );
+
+    const response = await api.listStrategiesV1({
+      xRequestId: parseRequestId(parsed.values),
+      status,
+      cursor: nonEmpty(parsed.values.cursor),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const items = (serial.items as Record<string, unknown>[]) ?? [];
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "strategy list", ...serial },
+      {
+        title: "strategy list",
+        notes: [`requestId: ${response.requestId}`, `nextCursor: ${response.nextCursor ?? "-"}`],
+        rows: items.map((item) => toStrategyTableRow(item)),
+        columns: ["id", "name", "status", "provider", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "update") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "strategy-id": { type: "string" },
+        input: { type: "string" },
+        name: { type: "string" },
+        description: { type: "string" },
+        status: { type: "string" },
+        tags: { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const strategyId = nonEmpty(parsed.values["strategy-id"]);
+    if (!strategyId) {
+      throw new Error("--strategy-id is required.");
+    }
+
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.updateStrategyV1({
+      strategyId,
+      updateStrategyRequest: parseUpdateStrategyRequest(parsed.values),
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const strategy = serial.strategy as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "strategy update", ...serial },
+      {
+        title: "strategy update",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toStrategyTableRow(strategy)],
+        columns: ["id", "name", "status", "provider", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  throw new Error(`Unknown strategy subcommand '${subcommand}'. Use 'create', 'get', 'list', or 'update'.`);
+}
+
+function parseCreateBacktestRequest(values: ParsedValues): CreateBacktestRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateBacktestRequest>(inputPath, "backtest create payload");
+  }
+
+  const startDate = parseRequiredDate(values["start-date"], "--start-date");
+  const endDate = parseRequiredDate(values["end-date"], "--end-date");
+  const datasetIds = parseCsv(values["dataset-ids"]);
+  const dataIds = parseCsv(values["data-ids"]);
+  const initialCashRaw = nonEmpty(values["initial-cash"]);
+  const initialCash = initialCashRaw ? parseNumeric(initialCashRaw, "--initial-cash") : undefined;
+
+  return {
+    startDate,
+    endDate,
+    ...(datasetIds.length > 0 ? { datasetIds } : {}),
+    ...(dataIds.length > 0 ? { dataIds } : {}),
+    ...(initialCash !== undefined ? { initialCash } : {}),
+  };
+}
+
+function serializeBacktestTable(backtest: Record<string, unknown>): TableRow {
+  return {
+    id: backtest.id as string,
+    strategyId: backtest.strategyId as string,
+    status: backtest.status as string,
+    startedAt: backtest.startedAt as string,
+    completedAt: backtest.completedAt as string,
+    createdAt: backtest.createdAt as string,
+  };
+}
+
+async function runBacktestCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    context.emit({
+      status: "ok",
+      command: "backtest",
+      usage: [
+        "trading-cli backtest create --strategy-id <id> --start-date 2025-01-01 --end-date 2025-03-01 [--dataset-ids <csv>] [--output json|table]",
+        "trading-cli backtest create --strategy-id <id> --input <create-backtest.json> [--output json|table]",
+        "trading-cli backtest get --backtest-id <id> [--output json|table]",
+      ],
+    });
+    return;
+  }
+
+  const api = createBacktestsApiClient(context);
+
+  if (subcommand === "create") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "strategy-id": { type: "string" },
+        input: { type: "string" },
+        "start-date": { type: "string" },
+        "end-date": { type: "string" },
+        "dataset-ids": { type: "string" },
+        "data-ids": { type: "string" },
+        "initial-cash": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const strategyId = nonEmpty(parsed.values["strategy-id"]);
+    if (!strategyId) {
+      throw new Error("--strategy-id is required.");
+    }
+
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.createBacktestV1({
+      strategyId,
+      createBacktestRequest: parseCreateBacktestRequest(parsed.values),
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const backtest = serial.backtest as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "backtest create", ...serial },
+      {
+        title: "backtest create",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [serializeBacktestTable(backtest)],
+        columns: ["id", "strategyId", "status", "startedAt", "completedAt", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "get") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "backtest-id": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const backtestId = nonEmpty(parsed.values["backtest-id"]);
+    if (!backtestId) {
+      throw new Error("--backtest-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.getBacktestV1({
+      backtestId,
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const backtest = serial.backtest as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "backtest get", ...serial },
+      {
+        title: "backtest get",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [serializeBacktestTable(backtest)],
+        columns: ["id", "strategyId", "status", "startedAt", "completedAt", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  throw new Error(`Unknown backtest subcommand '${subcommand}'. Use 'create' or 'get'.`);
+}
+
+function parseCreateDeploymentRequest(values: ParsedValues): CreateDeploymentRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateDeploymentRequest>(inputPath, "deploy create payload");
+  }
+
+  const strategyId = nonEmpty(values["strategy-id"]);
+  const mode = nonEmpty(values.mode)?.toLowerCase();
+  const capitalRaw = nonEmpty(values.capital);
+  if (!strategyId) {
+    throw new Error("--strategy-id is required when --input is not provided.");
+  }
+  if (!mode || (mode !== "paper" && mode !== "live")) {
+    throw new Error("--mode is required when --input is not provided and must be paper|live.");
+  }
+  if (!capitalRaw) {
+    throw new Error("--capital is required when --input is not provided.");
+  }
+
+  return {
+    strategyId,
+    mode: mode as CreateDeploymentRequest["mode"],
+    capital: parseNumeric(capitalRaw, "--capital"),
+  };
+}
+
+async function runDeployCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    context.emit({
+      status: "ok",
+      command: "deploy",
+      usage: [
+        "trading-cli deploy create --strategy-id <id> --mode paper|live --capital <amount> [--idempotency-key <key>] [--output json|table]",
+        "trading-cli deploy create --input <create-deployment.json> [--idempotency-key <key>] [--output json|table]",
+        "trading-cli deploy get --deployment-id <id> [--output json|table]",
+        "trading-cli deploy list [--status queued|running|paused|stopping|stopped|failed] [--cursor <token>] [--output json|table]",
+        "trading-cli deploy stop --deployment-id <id> [--reason <text>] [--output json|table]",
+      ],
+    });
+    return;
+  }
+
+  const api = createDeploymentsApiClient(context);
+
+  if (subcommand === "create") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        input: { type: "string" },
+        "strategy-id": { type: "string" },
+        mode: { type: "string" },
+        capital: { type: "string" },
+        "request-id": { type: "string" },
+        "idempotency-key": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.createDeploymentV1({
+      idempotencyKey: parseIdempotencyKey(parsed.values),
+      createDeploymentRequest: parseCreateDeploymentRequest(parsed.values),
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const deployment = serial.deployment as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "deploy create", ...serial },
+      {
+        title: "deploy create",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toDeploymentTableRow(deployment)],
+        columns: ["id", "strategyId", "mode", "status", "capital", "latestPnl"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "get") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "deployment-id": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const deploymentId = nonEmpty(parsed.values["deployment-id"]);
+    if (!deploymentId) {
+      throw new Error("--deployment-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.getDeploymentV1({
+      deploymentId,
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const deployment = serial.deployment as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "deploy get", ...serial },
+      {
+        title: "deploy get",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toDeploymentTableRow(deployment)],
+        columns: ["id", "strategyId", "mode", "status", "capital", "latestPnl"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "list") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        status: { type: "string" },
+        cursor: { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const output = parseOutputMode(parsed.values.output);
+    const status = parseEnumValue<DeploymentStatus>(
+      parsed.values.status,
+      "--status",
+      DEPLOYMENT_STATUSES,
+    );
+    const response = await api.listDeploymentsV1({
+      xRequestId: parseRequestId(parsed.values),
+      status,
+      cursor: nonEmpty(parsed.values.cursor),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const items = (serial.items as Record<string, unknown>[]) ?? [];
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "deploy list", ...serial },
+      {
+        title: "deploy list",
+        notes: [`requestId: ${response.requestId}`, `nextCursor: ${response.nextCursor ?? "-"}`],
+        rows: items.map((item) => toDeploymentTableRow(item)),
+        columns: ["id", "strategyId", "mode", "status", "capital", "latestPnl"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "stop") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "deployment-id": { type: "string" },
+        reason: { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const deploymentId = nonEmpty(parsed.values["deployment-id"]);
+    if (!deploymentId) {
+      throw new Error("--deployment-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+    const reason = nonEmpty(parsed.values.reason);
+
+    const response = await api.stopDeploymentV1({
+      deploymentId,
+      xRequestId: parseRequestId(parsed.values),
+      stopDeploymentV1Request: reason ? { reason } : undefined,
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const deployment = serial.deployment as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "deploy stop", ...serial },
+      {
+        title: "deploy stop",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toDeploymentTableRow(deployment)],
+        columns: ["id", "strategyId", "mode", "status", "capital", "latestPnl"],
+      },
+    );
+    return;
+  }
+
+  throw new Error(`Unknown deploy subcommand '${subcommand}'. Use 'create', 'get', 'list', or 'stop'.`);
+}
+
+async function runPortfolioCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    context.emit({
+      status: "ok",
+      command: "portfolio",
+      usage: [
+        "trading-cli portfolio list [--output json|table]",
+        "trading-cli portfolio get --portfolio-id <id> [--output json|table]",
+      ],
+    });
+    return;
+  }
+
+  const api = createPortfoliosApiClient(context);
+
+  if (subcommand === "list") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+    const output = parseOutputMode(parsed.values.output);
+
+    const response = await api.listPortfoliosV1({
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const items = (serial.items as Record<string, unknown>[]) ?? [];
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "portfolio list", ...serial },
+      {
+        title: "portfolio list",
+        notes: [`requestId: ${response.requestId}`],
+        rows: items.map((item) => toPortfolioTableRow(item)),
+        columns: ["id", "mode", "cash", "totalValue", "pnlTotal", "positions"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "get") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "portfolio-id": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+    const portfolioId = nonEmpty(parsed.values["portfolio-id"]);
+    if (!portfolioId) {
+      throw new Error("--portfolio-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.getPortfolioV1({
+      portfolioId,
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const portfolio = serial.portfolio as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "portfolio get", ...serial },
+      {
+        title: "portfolio get",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toPortfolioTableRow(portfolio)],
+        columns: ["id", "mode", "cash", "totalValue", "pnlTotal", "positions"],
+      },
+    );
+    return;
+  }
+
+  throw new Error(`Unknown portfolio subcommand '${subcommand}'. Use 'list' or 'get'.`);
+}
+
+function parseCreateOrderRequest(values: ParsedValues): CreateOrderRequest {
+  const inputPath = nonEmpty(values.input);
+  if (!inputPath) {
+    throw new Error("--input is required for order create.");
+  }
+  return parseJsonFile<CreateOrderRequest>(inputPath, "order create payload");
+}
+
+async function runOrderCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    context.emit({
+      status: "ok",
+      command: "order",
+      usage: [
+        "trading-cli order create --input <create-order.json> [--idempotency-key <key>] [--output json|table]",
+        "trading-cli order get --order-id <id> [--output json|table]",
+        "trading-cli order list [--status pending|filled|cancelled|failed] [--cursor <token>] [--output json|table]",
+        "trading-cli order cancel --order-id <id> [--output json|table]",
+      ],
+    });
+    return;
+  }
+
+  const api = createOrdersApiClient(context);
+
+  if (subcommand === "create") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        input: { type: "string" },
+        "request-id": { type: "string" },
+        "idempotency-key": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+    const output = parseOutputMode(parsed.values.output);
+
+    const response = await api.createOrderV1({
+      idempotencyKey: parseIdempotencyKey(parsed.values),
+      createOrderRequest: parseCreateOrderRequest(parsed.values),
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const order = serial.order as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "order create", ...serial },
+      {
+        title: "order create",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toOrderTableRow(order)],
+        columns: ["id", "symbol", "side", "type", "quantity", "status", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "get") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "order-id": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+    const orderId = nonEmpty(parsed.values["order-id"]);
+    if (!orderId) {
+      throw new Error("--order-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+
+    const response = await api.getOrderV1({
+      orderId,
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const order = serial.order as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "order get", ...serial },
+      {
+        title: "order get",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toOrderTableRow(order)],
+        columns: ["id", "symbol", "side", "type", "quantity", "status", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "list") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        status: { type: "string" },
+        cursor: { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const output = parseOutputMode(parsed.values.output);
+    const status = parseEnumValue<OrderStatus>(parsed.values.status, "--status", ORDER_STATUSES);
+    const response = await api.listOrdersV1({
+      xRequestId: parseRequestId(parsed.values),
+      status,
+      cursor: nonEmpty(parsed.values.cursor),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const items = (serial.items as Record<string, unknown>[]) ?? [];
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "order list", ...serial },
+      {
+        title: "order list",
+        notes: [`requestId: ${response.requestId}`, `nextCursor: ${response.nextCursor ?? "-"}`],
+        rows: items.map((item) => toOrderTableRow(item)),
+        columns: ["id", "symbol", "side", "type", "quantity", "status", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  if (subcommand === "cancel") {
+    const parsed = parseArgs({
+      args: args.slice(1),
+      options: {
+        "order-id": { type: "string" },
+        "request-id": { type: "string" },
+        output: { type: "string" },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+
+    const orderId = nonEmpty(parsed.values["order-id"]);
+    if (!orderId) {
+      throw new Error("--order-id is required.");
+    }
+    const output = parseOutputMode(parsed.values.output);
+    const response = await api.cancelOrderV1({
+      orderId,
+      xRequestId: parseRequestId(parsed.values),
+    });
+
+    const serial = toSerializable(response) as Record<string, unknown>;
+    const order = serial.order as Record<string, unknown>;
+    emitOutput(
+      context,
+      output,
+      { status: "ok", command: "order cancel", ...serial },
+      {
+        title: "order cancel",
+        notes: [`requestId: ${response.requestId}`],
+        rows: [toOrderTableRow(order)],
+        columns: ["id", "symbol", "side", "type", "quantity", "status", "createdAt"],
+      },
+    );
+    return;
+  }
+
+  throw new Error(`Unknown order subcommand '${subcommand}'. Use 'create', 'get', 'list', or 'cancel'.`);
+}
+
+export async function runCoreCommand(args: string[], context: CommandContext): Promise<void> {
+  const group = args[0];
+  if (!group || group === "--help" || group === "-h") {
+    context.emit({
+      status: "ok",
+      command: "core",
+      groups: ["research", "strategy", "backtest", "deploy", "portfolio", "order"],
+    });
+    return;
+  }
+
+  if (group === "research") {
+    await runResearchCommand(args.slice(1), context);
+    return;
+  }
+
+  if (group === "strategy") {
+    await runStrategyCommand(args.slice(1), context);
+    return;
+  }
+
+  if (group === "backtest") {
+    await runBacktestCommand(args.slice(1), context);
+    return;
+  }
+
+  if (group === "deploy") {
+    await runDeployCommand(args.slice(1), context);
+    return;
+  }
+
+  if (group === "portfolio") {
+    await runPortfolioCommand(args.slice(1), context);
+    return;
+  }
+
+  if (group === "order") {
+    await runOrderCommand(args.slice(1), context);
+    return;
+  }
+
+  throw new Error(`Unsupported core command group '${group}'.`);
+}

--- a/src/platform-api-sdk.ts
+++ b/src/platform-api-sdk.ts
@@ -1,0 +1,115 @@
+import { type CommandContext, nonEmpty, trimTrailingSlash } from "./command-utils";
+import {
+  BacktestsApi,
+  Configuration,
+  ConversationsApi,
+  DatasetsApi,
+  DeploymentsApi,
+  OrdersApi,
+  PortfoliosApi,
+  ResearchApi,
+  SharedValidationApi,
+  StrategiesApi,
+  ValidationApi,
+} from "./generated/trade-nexus-sdk";
+
+export type PlatformApiClientOptions = {
+  requireAuth?: boolean;
+};
+
+function resolveAuth(env: NodeJS.ProcessEnv): { accessToken?: string; apiKey?: string } {
+  const accessToken = nonEmpty(env.PLATFORM_API_BEARER_TOKEN) ?? nonEmpty(env.PLATFORM_API_TOKEN);
+  const apiKey = nonEmpty(env.PLATFORM_API_KEY);
+  return { accessToken, apiKey };
+}
+
+function createConfiguration(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): Configuration {
+  const { requireAuth = true } = options;
+  const auth = resolveAuth(context.env);
+
+  if (requireAuth && !auth.accessToken && !auth.apiKey) {
+    throw new Error(
+      "Authentication required: set PLATFORM_API_BEARER_TOKEN (preferred) or PLATFORM_API_KEY.",
+    );
+  }
+
+  return new Configuration({
+    basePath: trimTrailingSlash(context.baseUrl),
+    fetchApi: context.fetchImpl,
+    accessToken: auth.accessToken,
+    apiKey: auth.apiKey,
+  });
+}
+
+export function createValidationApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): ValidationApi {
+  return new ValidationApi(createConfiguration(context, options));
+}
+
+export function createResearchApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): ResearchApi {
+  return new ResearchApi(createConfiguration(context, options));
+}
+
+export function createStrategiesApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): StrategiesApi {
+  return new StrategiesApi(createConfiguration(context, options));
+}
+
+export function createBacktestsApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): BacktestsApi {
+  return new BacktestsApi(createConfiguration(context, options));
+}
+
+export function createDeploymentsApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): DeploymentsApi {
+  return new DeploymentsApi(createConfiguration(context, options));
+}
+
+export function createPortfoliosApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): PortfoliosApi {
+  return new PortfoliosApi(createConfiguration(context, options));
+}
+
+export function createOrdersApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): OrdersApi {
+  return new OrdersApi(createConfiguration(context, options));
+}
+
+export function createDatasetsApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): DatasetsApi {
+  return new DatasetsApi(createConfiguration(context, options));
+}
+
+export function createSharedValidationApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): SharedValidationApi {
+  return new SharedValidationApi(createConfiguration(context, options));
+}
+
+export function createConversationsApiClient(
+  context: CommandContext,
+  options: PlatformApiClientOptions = {},
+): ConversationsApi {
+  return new ConversationsApi(createConfiguration(context, options));
+}

--- a/src/validation-api-client.ts
+++ b/src/validation-api-client.ts
@@ -1,35 +1,13 @@
-import { type CommandContext, nonEmpty, trimTrailingSlash } from "./command-utils";
-import { Configuration, ValidationApi } from "./generated/trade-nexus-sdk";
+import type { CommandContext } from "./command-utils";
+import { type PlatformApiClientOptions, createValidationApiClient as createValidationApi } from "./platform-api-sdk";
 
 type ValidationApiClientOptions = {
   requireAuth?: boolean;
 };
 
-function resolveAuth(env: NodeJS.ProcessEnv): { accessToken?: string; apiKey?: string } {
-  const accessToken = nonEmpty(env.PLATFORM_API_BEARER_TOKEN) ?? nonEmpty(env.PLATFORM_API_TOKEN);
-  const apiKey = nonEmpty(env.PLATFORM_API_KEY);
-  return { accessToken, apiKey };
-}
-
 export function createValidationApiClient(
   context: CommandContext,
   options: ValidationApiClientOptions = {},
-): ValidationApi {
-  const { requireAuth = true } = options;
-  const auth = resolveAuth(context.env);
-
-  if (requireAuth && !auth.accessToken && !auth.apiKey) {
-    throw new Error(
-      "Authentication required: set PLATFORM_API_BEARER_TOKEN (preferred) or PLATFORM_API_KEY.",
-    );
-  }
-
-  const configuration = new Configuration({
-    basePath: trimTrailingSlash(context.baseUrl),
-    fetchApi: context.fetchImpl,
-    accessToken: auth.accessToken,
-    apiKey: auth.apiKey,
-  });
-
-  return new ValidationApi(configuration);
+) {
+  return createValidationApi(context, options as PlatformApiClientOptions);
 }

--- a/tests/smoke/core-cli.test.ts
+++ b/tests/smoke/core-cli.test.ts
@@ -1,0 +1,367 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { run } from "../../src/cli";
+
+type RecordedRequest = {
+  path: string;
+  method: string;
+  headers: Headers;
+  body?: unknown;
+};
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+const ORIGINAL_ERROR = console.error;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  console.log = ORIGINAL_LOG;
+  console.error = ORIGINAL_ERROR;
+  delete process.env.PLATFORM_API_BASE_URL;
+  delete process.env.PLATFORM_API_BEARER_TOKEN;
+  delete process.env.PLATFORM_API_TOKEN;
+  delete process.env.PLATFORM_API_KEY;
+});
+
+describe("core command groups", () => {
+  test("research/strategy/backtest/deploy/portfolio/order map to canonical endpoints", async () => {
+    const requests: RecordedRequest[] = [];
+    const logs: string[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-core-001";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ path: url.pathname, method, headers, body });
+
+      if (url.pathname === "/v2/research/market-scan" && method === "POST") {
+        return jsonResponse({
+          requestId: "req-research-001",
+          regimeSummary: "risk-on",
+          strategyIdeas: [
+            {
+              name: "Breakout",
+              assetClass: "crypto",
+              description: "Momentum breakout",
+            },
+          ],
+          knowledgeEvidence: [],
+          dataContextSummary: "none",
+        });
+      }
+
+      if (url.pathname === "/v1/strategies" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-strategy-list-001",
+          items: [
+            {
+              id: "strat-001",
+              name: "Breakout",
+              status: "tested",
+              provider: "lona",
+              providerRefId: "provider-001",
+              tags: ["momentum"],
+              createdAt: "2026-03-01T10:00:00Z",
+              updatedAt: "2026-03-01T10:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        });
+      }
+
+      if (url.pathname === "/v1/backtests/backtest-001" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-backtest-get-001",
+          backtest: {
+            id: "backtest-001",
+            strategyId: "strat-001",
+            status: "completed",
+            startedAt: "2026-02-01T00:00:00Z",
+            completedAt: "2026-02-02T00:00:00Z",
+            metrics: { pnlPct: 3.2 },
+            error: null,
+            createdAt: "2026-02-01T00:00:00Z",
+          },
+        });
+      }
+
+      if (url.pathname === "/v1/deployments" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-deploy-list-001",
+          items: [
+            {
+              id: "deploy-001",
+              strategyId: "strat-001",
+              mode: "paper",
+              status: "running",
+              capital: 10000,
+              latestPnl: 120.5,
+              createdAt: "2026-03-01T08:00:00Z",
+              updatedAt: "2026-03-01T10:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        });
+      }
+
+      if (url.pathname === "/v1/portfolios" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-portfolio-list-001",
+          items: [
+            {
+              id: "portfolio-001",
+              mode: "paper",
+              cash: 9500,
+              totalValue: 10120,
+              pnlTotal: 120,
+              positions: [],
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/v1/orders" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-order-list-001",
+          items: [
+            {
+              id: "order-001",
+              symbol: "BTCUSDT",
+              side: "buy",
+              type: "market",
+              quantity: 0.1,
+              price: null,
+              status: "filled",
+              deploymentId: null,
+              createdAt: "2026-03-01T11:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        });
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "research",
+          "scan",
+          "--asset-classes",
+          "crypto",
+          "--capital",
+          "25000",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "strategy", "list"], fetchMock)).toBe(0);
+    expect(
+      await run(["bun", "src/cli.ts", "backtest", "get", "--backtest-id", "backtest-001"], fetchMock),
+    ).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "deploy", "list"], fetchMock)).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "portfolio", "list"], fetchMock)).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "order", "list"], fetchMock)).toBe(0);
+
+    expect(requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "POST /v2/research/market-scan",
+      "GET /v1/strategies",
+      "GET /v1/backtests/backtest-001",
+      "GET /v1/deployments",
+      "GET /v1/portfolios",
+      "GET /v1/orders",
+    ]);
+
+    const researchPayload = JSON.parse(logs[0] ?? "{}") as { status: string; command: string };
+    const strategyPayload = JSON.parse(logs[1] ?? "{}") as { command: string; requestId: string };
+    expect(researchPayload.status).toBe("ok");
+    expect(researchPayload.command).toBe("research scan");
+    expect(strategyPayload.command).toBe("strategy list");
+    expect(strategyPayload.requestId).toBe("req-strategy-list-001");
+  });
+
+  test("deploy create sends idempotency header and table output is deterministic", async () => {
+    const logs: string[] = [];
+    const requests: RecordedRequest[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-core-002";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ path: url.pathname, method, headers, body });
+
+      if (url.pathname === "/v1/deployments" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-deploy-create-001",
+            deployment: {
+              id: "deploy-002",
+              strategyId: "strat-001",
+              mode: "paper",
+              status: "queued",
+              capital: 12000,
+              latestPnl: null,
+              createdAt: "2026-03-01T12:00:00Z",
+              updatedAt: "2026-03-01T12:00:00Z",
+            },
+          },
+          202,
+        );
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    const exitCode = await run(
+      [
+        "bun",
+        "src/cli.ts",
+        "deploy",
+        "create",
+        "--strategy-id",
+        "strat-001",
+        "--mode",
+        "paper",
+        "--capital",
+        "12000",
+        "--idempotency-key",
+        "idem-core-fixed-001",
+        "--request-id",
+        "req-core-fixed-001",
+        "--output",
+        "table",
+      ],
+      fetchMock,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests.length).toBe(1);
+    expect(requests[0]?.path).toBe("/v1/deployments");
+    expect(requests[0]?.headers.get("Idempotency-Key")).toBe("idem-core-fixed-001");
+    expect(requests[0]?.headers.get("X-Request-Id")).toBe("req-core-fixed-001");
+    expect(logs.at(-1) ?? "").toContain("deploy create");
+    expect(logs.at(-1) ?? "").toContain("id");
+    expect(logs.at(-1) ?? "").toContain("deploy-002");
+  });
+
+  test("order create requires input payload file", async () => {
+    const errors: string[] = [];
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-core-003";
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    const exitCode = await run(["bun", "src/cli.ts", "order", "create"]);
+    expect(exitCode).toBe(1);
+
+    const envelope = JSON.parse(errors.at(-1) ?? "{}") as { status: string; message: string };
+    expect(envelope.status).toBe("error");
+    expect(envelope.message).toContain("--input is required");
+  });
+
+  test("order create accepts payload json file", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "core-order-"));
+    const payloadPath = join(tmp, "order.json");
+    writeFileSync(payloadPath, JSON.stringify({ type: "market" }), "utf-8");
+
+    const logs: string[] = [];
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-core-004";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      if (url.pathname === "/v1/orders" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-order-create-001",
+            order: {
+              id: "order-002",
+              symbol: "BTCUSDT",
+              side: "buy",
+              type: "market",
+              quantity: 0.1,
+              price: null,
+              status: "pending",
+              deploymentId: null,
+              createdAt: "2026-03-01T12:15:00Z",
+            },
+          },
+          201,
+        );
+      }
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    try {
+      const exitCode = await run(
+        ["bun", "src/cli.ts", "order", "create", "--input", payloadPath],
+        fetchMock,
+      );
+      expect(exitCode).toBe(0);
+
+      const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+        status: string;
+        command: string;
+        order: { id: string };
+      };
+      expect(payload.status).toBe("ok");
+      expect(payload.command).toBe("order create");
+      expect(payload.order.id).toBe("order-002");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement Phase 2 CORE lane command groups for external parity
- add canonical SDK routing for `research`, `strategy`, `backtest`, `deploy`, `portfolio`, and `order`
- add deterministic output mode support (`--output json|table`) with stable serialization and table rendering
- preserve existing command groups (`review-run`, `validation run`, `register/key`)

## SDK mapping
- `research scan` -> `ResearchApi.postMarketScanV1/V2`
- `strategy create|get|list|update` -> `StrategiesApi.*`
- `backtest create|get` -> `BacktestsApi.*`
- `deploy create|get|list|stop` -> `DeploymentsApi.*`
- `portfolio list|get` -> `PortfoliosApi.*`
- `order create|get|list|cancel` -> `OrdersApi.*`

## Tests
- added `tests/smoke/core-cli.test.ts` covering endpoint mapping, idempotency/request headers, table output determinism, and required pre-flight args.

## Required validation evidence
- `bun install --frozen-lockfile` ✅
- `bun run build` ✅
- `bun test` ✅ (`25 pass, 2 skip, 0 fail`)
- `npm pack --dry-run` ✅
- `bun run sdk:drift` ✅
- `bun run sdk:drift --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml` ✅

## Tracking
- Closes #22
- Refs #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new CLI surface area that issues authenticated Platform API requests (including idempotent create operations) and changes command routing, so regressions could affect real trading workflows if endpoints/flags are miswired. Table formatting/serialization changes also impact output contracts relied on by scripts.
> 
> **Overview**
> Adds **Phase 2 CORE CLI command groups** (`research`, `strategy`, `backtest`, `deploy`, `portfolio`, `order`) and routes them from `src/cli.ts` to a new `runCoreCommand`, while keeping existing `review-run`, `validation`, and bot registration/key commands intact.
> 
> Introduces a shared `platform-api-sdk` for authenticated SDK client creation (and refactors `validation-api-client` to use it), plus new output helpers in `command-utils` to support `--output json|table` with stable serialization and deterministic table rendering.
> 
> Adds smoke tests covering endpoint mapping, request/idempotency headers, table output determinism, and required argument validation for the new command groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a602097038e1460c6906bfe378c0cf82b6c84b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented Phase 2 CORE command groups (`research`, `strategy`, `backtest`, `deploy`, `portfolio`, `order`) with canonical SDK routing to Platform API endpoints.

**Major Changes:**
- Added complete command handlers for six new command groups in `src/core-command.ts` (1202 lines)
- Centralized SDK client creation and authentication logic in `src/platform-api-sdk.ts`
- Implemented dual output modes (`--output json|table`) with deterministic table rendering
- Refactored `validation-api-client.ts` to use centralized auth, eliminating code duplication
- Added comprehensive smoke tests covering endpoint mapping, idempotency headers, and output formatting

**SDK Mapping:**
- `research scan` → `ResearchApi.postMarketScanV1/V2`
- `strategy create|get|list|update` → `StrategiesApi.*`
- `backtest create|get` → `BacktestsApi.*`
- `deploy create|get|list|stop` → `DeploymentsApi.*`
- `portfolio list|get` → `PortfoliosApi.*`
- `order create|get|list|cancel` → `OrdersApi.*`

All existing command groups (`review-run`, `validation run`, `register`, `key`) remain unchanged, maintaining backward compatibility.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no critical issues found
- Score reflects comprehensive test coverage (25 passing tests), clean architecture with centralized authentication, well-structured error handling, and successful validation evidence (build, tests, and SDK drift checks all pass). The implementation follows consistent patterns, maintains backward compatibility, and adds substantial functionality without introducing security vulnerabilities or logic errors.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli.ts | Added routing for six new core command groups (research, strategy, backtest, deploy, portfolio, order) to the CLI entry point |
| src/command-utils.ts | Added output formatting utilities including parseOutputMode, toSerializable, and formatTable for deterministic table rendering |
| src/core-command.ts | Implemented complete command handlers for research, strategy, backtest, deploy, portfolio, and order groups with SDK routing, argument parsing, and dual output modes |
| src/platform-api-sdk.ts | Created centralized SDK client factory functions with consolidated authentication logic for all Platform API clients |
| src/validation-api-client.ts | Refactored to delegate to centralized platform-api-sdk authentication, eliminating code duplication |
| tests/smoke/core-cli.test.ts | Added comprehensive smoke tests covering endpoint routing, idempotency headers, table output determinism, and input validation |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI[CLI Entry Point<br/>src/cli.ts] --> ROUTE{Command<br/>Group?}
    
    ROUTE -->|research| CORE[Core Command Handler<br/>src/core-command.ts]
    ROUTE -->|strategy| CORE
    ROUTE -->|backtest| CORE
    ROUTE -->|deploy| CORE
    ROUTE -->|portfolio| CORE
    ROUTE -->|order| CORE
    ROUTE -->|review-run| REVIEW[Review Run Command]
    ROUTE -->|validation| VALIDATION[Validation Command]
    ROUTE -->|register/key| BOT[Validation Bot Command]
    
    CORE --> PARSE[Parse Args & Validate]
    PARSE --> SDK[Platform API SDK<br/>src/platform-api-sdk.ts]
    
    SDK --> AUTH{Auth<br/>Required?}
    AUTH -->|Yes| RESOLVE[Resolve Auth<br/>BEARER_TOKEN or API_KEY]
    AUTH -->|No| CONFIG[Create Configuration]
    RESOLVE --> CONFIG
    
    CONFIG --> API{API Client}
    API -->|research| RESEARCH_API[ResearchApi]
    API -->|strategy| STRATEGY_API[StrategiesApi]
    API -->|backtest| BACKTEST_API[BacktestsApi]
    API -->|deploy| DEPLOY_API[DeploymentsApi]
    API -->|portfolio| PORTFOLIO_API[PortfoliosApi]
    API -->|order| ORDER_API[OrdersApi]
    
    RESEARCH_API --> PLATFORM[Platform API<br/>api-nexus.lona.agency]
    STRATEGY_API --> PLATFORM
    BACKTEST_API --> PLATFORM
    DEPLOY_API --> PLATFORM
    PORTFOLIO_API --> PLATFORM
    ORDER_API --> PLATFORM
    
    PLATFORM --> RESPONSE[API Response]
    RESPONSE --> FORMAT{Output<br/>Mode?}
    FORMAT -->|json| JSON[JSON Output<br/>context.emit]
    FORMAT -->|table| TABLE[Table Formatter<br/>formatTable]
    
    JSON --> OUTPUT[stdout]
    TABLE --> OUTPUT
    
    style CORE fill:#e1f5ff
    style SDK fill:#fff3e0
    style PLATFORM fill:#f3e5f5
    style OUTPUT fill:#e8f5e9
```

<sub>Last reviewed commit: 4a60209</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->