### PR TITLE
feat(dataset): phase2 lifecycle parity command group

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { formatReviewRunError, runReviewRunCommand } from "./review-run-command";
 import { runValidationBotCommand } from "./validation-bot-command";
 import { runCoreCommand } from "./core-command";
+import { runDatasetCommand } from "./dataset-command";
 
 const BLOCKED_PROVIDER_HOST_HINTS = [
   "lona",
@@ -113,6 +114,8 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
         "deploy create|get|list|stop",
         "portfolio list|get",
         "order create|get|list|cancel",
+        "dataset upload init|complete",
+        "dataset validate|transform|publish|get|status|list",
       ],
     });
     return 0;
@@ -158,12 +161,17 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
       return 0;
     }
 
+    if (args[0] === "dataset") {
+      await runDatasetCommand(args.slice(1), context);
+      return 0;
+    }
+
     emitError({
       status: "error",
       message:
         `Unknown command '${args[0]}'. Use 'review-run', 'validation run', ` +
         "'register', 'key', 'bot', 'research', 'strategy', 'backtest', " +
-        "'deploy', 'portfolio', or 'order'.",
+        "'deploy', 'portfolio', 'order', or 'dataset'.",
       command: args,
       target: baseUrl,
     });

--- a/src/dataset-command.ts
+++ b/src/dataset-command.ts
@@ -1,0 +1,623 @@
+import { parseArgs } from "node:util";
+
+import {
+  type CommandContext,
+  deriveRequestId,
+  formatTable,
+  nonEmpty,
+  parseJsonFile,
+  parseOutputMode,
+  toSerializable,
+  type OutputMode,
+  type TableRow,
+} from "./command-utils";
+import { DatasetPublishMode, type DatasetUploadCompleteRequest, type DatasetUploadInitRequest, type DatasetValidateRequest } from "./generated/trade-nexus-sdk";
+import { createDatasetsApiClient } from "./platform-api-sdk";
+
+type ParsedValues = ReturnType<typeof parseArgs>["values"];
+
+const DATASET_REQUEST_ID_PREFIX = "req-dataset";
+const DATASET_PUBLISH_MODES = new Set<string>(Object.values(DatasetPublishMode));
+
+type TableOutput = {
+  title?: string;
+  rows: TableRow[];
+  columns: string[];
+  notes?: string[];
+  emptyMessage?: string;
+};
+
+function parseRequestId(values: ParsedValues): string {
+  return deriveRequestId(DATASET_REQUEST_ID_PREFIX, nonEmpty(values["request-id"]));
+}
+
+function parseCsv(value: unknown): string[] {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function emitOutput(
+  context: CommandContext,
+  output: OutputMode,
+  payload: unknown,
+  table?: TableOutput,
+): void {
+  const serial = toSerializable(payload);
+  if (output === "json") {
+    context.emit(serial);
+    return;
+  }
+
+  if (!table) {
+    console.log(JSON.stringify(serial, null, 2));
+    return;
+  }
+
+  const lines: string[] = [];
+  if (table.title) {
+    lines.push(table.title);
+  }
+  if (table.notes && table.notes.length > 0) {
+    lines.push(...table.notes);
+  }
+  if (table.rows.length === 0) {
+    lines.push(table.emptyMessage ?? "(no rows)");
+  } else {
+    lines.push(formatTable(table.rows, table.columns));
+  }
+  console.log(lines.join("\n"));
+}
+
+function parseIntValue(value: unknown, label: string): number {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    throw new Error(`${label} is required.`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function parseDatasetTable(dataset: Record<string, unknown>): TableRow {
+  return {
+    id: dataset.id as string,
+    filename: dataset.filename as string,
+    contentType: dataset.contentType as string,
+    sizeBytes: dataset.sizeBytes as number,
+    status: dataset.status as string,
+    providerDataId: dataset.providerDataId as string | null | undefined,
+    updatedAt: dataset.updatedAt as string,
+  };
+}
+
+function parseInitRequest(values: ParsedValues): DatasetUploadInitRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<DatasetUploadInitRequest>(inputPath, "dataset upload init payload");
+  }
+
+  const filename = nonEmpty(values.filename);
+  const contentType = nonEmpty(values["content-type"]);
+  const sizeBytes = parseIntValue(values["size-bytes"], "--size-bytes");
+  if (!filename) {
+    throw new Error("--filename is required when --input is not provided.");
+  }
+  if (!contentType) {
+    throw new Error("--content-type is required when --input is not provided.");
+  }
+
+  return {
+    filename,
+    contentType,
+    sizeBytes,
+  };
+}
+
+function parseUploadCompleteRequest(values: ParsedValues): DatasetUploadCompleteRequest | undefined {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<DatasetUploadCompleteRequest>(inputPath, "dataset upload complete payload");
+  }
+  const uploadToken = nonEmpty(values["upload-token"]);
+  if (!uploadToken) {
+    return undefined;
+  }
+  return { uploadToken };
+}
+
+function parseValidateRequest(values: ParsedValues): DatasetValidateRequest | undefined {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<DatasetValidateRequest>(inputPath, "dataset validate payload");
+  }
+  const mappingRaw = nonEmpty(values["column-mapping-json"]);
+  if (!mappingRaw) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(mappingRaw);
+  } catch (error) {
+    throw new Error(
+      `Unable to parse --column-mapping-json: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("--column-mapping-json must be a JSON object.");
+  }
+  return {
+    columnMapping: parsed as Record<string, string>,
+  };
+}
+
+async function runUploadInitCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      input: { type: "string" },
+      filename: { type: "string" },
+      "content-type": { type: "string" },
+      "size-bytes": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.initDatasetUploadV1({
+    datasetUploadInitRequest: parseInitRequest(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "dataset upload init",
+      requestId: response.requestId,
+      datasetId: response.datasetId,
+      uploadUrl: response.uploadUrl,
+      datasetStatus: response.status,
+    },
+    {
+      title: "dataset upload init",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [
+        {
+          datasetId: response.datasetId,
+          status: response.status,
+          uploadUrl: response.uploadUrl,
+        },
+      ],
+      columns: ["datasetId", "status", "uploadUrl"],
+    },
+  );
+}
+
+async function runUploadCompleteCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "dataset-id": { type: "string" },
+      input: { type: "string" },
+      "upload-token": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const datasetId = nonEmpty(parsed.values["dataset-id"]);
+  if (!datasetId) {
+    throw new Error("--dataset-id is required.");
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.completeDatasetUploadV1({
+    datasetId,
+    xRequestId: parseRequestId(parsed.values),
+    datasetUploadCompleteRequest: parseUploadCompleteRequest(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const dataset = serial.dataset as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "dataset upload complete",
+      ...serial,
+    },
+    {
+      title: "dataset upload complete",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [parseDatasetTable(dataset)],
+      columns: ["id", "filename", "contentType", "sizeBytes", "status", "providerDataId", "updatedAt"],
+    },
+  );
+}
+
+async function runValidateCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "dataset-id": { type: "string" },
+      input: { type: "string" },
+      "column-mapping-json": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const datasetId = nonEmpty(parsed.values["dataset-id"]);
+  if (!datasetId) {
+    throw new Error("--dataset-id is required.");
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.validateDatasetV1({
+    datasetId,
+    xRequestId: parseRequestId(parsed.values),
+    datasetValidateRequest: parseValidateRequest(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const dataset = serial.dataset as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "dataset validate",
+      ...serial,
+    },
+    {
+      title: "dataset validate",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [parseDatasetTable(dataset)],
+      columns: ["id", "filename", "contentType", "sizeBytes", "status", "providerDataId", "updatedAt"],
+    },
+  );
+}
+
+async function runTransformCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "dataset-id": { type: "string" },
+      input: { type: "string" },
+      frequency: { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const datasetId = nonEmpty(parsed.values["dataset-id"]);
+  if (!datasetId) {
+    throw new Error("--dataset-id is required.");
+  }
+
+  let transformRequest;
+  const inputPath = nonEmpty(parsed.values.input);
+  if (inputPath) {
+    transformRequest = parseJsonFile<{ frequency: string }>(inputPath, "dataset transform payload");
+  } else {
+    const frequency = nonEmpty(parsed.values.frequency);
+    if (!frequency) {
+      throw new Error("--frequency is required when --input is not provided.");
+    }
+    transformRequest = { frequency };
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.transformDatasetCandlesV1({
+    datasetId,
+    datasetTransformCandlesRequest: transformRequest,
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const dataset = serial.dataset as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "dataset transform",
+      ...serial,
+    },
+    {
+      title: "dataset transform",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [parseDatasetTable(dataset)],
+      columns: ["id", "filename", "contentType", "sizeBytes", "status", "providerDataId", "updatedAt"],
+    },
+  );
+}
+
+async function runPublishCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "dataset-id": { type: "string" },
+      input: { type: "string" },
+      mode: { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const datasetId = nonEmpty(parsed.values["dataset-id"]);
+  if (!datasetId) {
+    throw new Error("--dataset-id is required.");
+  }
+
+  let publishRequest: { mode?: DatasetPublishMode } | undefined;
+  const inputPath = nonEmpty(parsed.values.input);
+  if (inputPath) {
+    publishRequest = parseJsonFile<{ mode?: DatasetPublishMode }>(inputPath, "dataset publish payload");
+  } else {
+    const mode = nonEmpty(parsed.values.mode)?.toLowerCase();
+    if (mode) {
+      if (!DATASET_PUBLISH_MODES.has(mode)) {
+        throw new Error(`--mode must be one of: ${Array.from(DATASET_PUBLISH_MODES).join(", ")}.`);
+      }
+      publishRequest = { mode: mode as DatasetPublishMode };
+    }
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.publishDatasetLonaV1({
+    datasetId,
+    xRequestId: parseRequestId(parsed.values),
+    datasetPublishLonaRequest: publishRequest,
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const dataset = serial.dataset as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "dataset publish",
+      ...serial,
+    },
+    {
+      title: "dataset publish",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [parseDatasetTable(dataset)],
+      columns: ["id", "filename", "contentType", "sizeBytes", "status", "providerDataId", "updatedAt"],
+    },
+  );
+}
+
+async function runGetOrStatusCommand(
+  args: string[],
+  context: CommandContext,
+  commandLabel: "dataset get" | "dataset status",
+): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "dataset-id": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const datasetId = nonEmpty(parsed.values["dataset-id"]);
+  if (!datasetId) {
+    throw new Error("--dataset-id is required.");
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.getDatasetV1({
+    datasetId,
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const dataset = serial.dataset as Record<string, unknown>;
+
+  if (commandLabel === "dataset status") {
+    emitOutput(
+      context,
+      output,
+      {
+        status: "ok",
+        command: commandLabel,
+        requestId: serial.requestId,
+        dataset: {
+          id: dataset.id,
+          status: dataset.status,
+          providerDataId: dataset.providerDataId,
+          updatedAt: dataset.updatedAt,
+        },
+      },
+      {
+        title: "dataset status",
+        notes: [`requestId: ${String(serial.requestId)}`],
+        rows: [
+          {
+            id: dataset.id as string,
+            status: dataset.status as string,
+            providerDataId: dataset.providerDataId as string | null | undefined,
+            updatedAt: dataset.updatedAt as string,
+          },
+        ],
+        columns: ["id", "status", "providerDataId", "updatedAt"],
+      },
+    );
+    return;
+  }
+
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: commandLabel,
+      ...serial,
+    },
+    {
+      title: "dataset get",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [parseDatasetTable(dataset)],
+      columns: ["id", "filename", "contentType", "sizeBytes", "status", "providerDataId", "updatedAt"],
+    },
+  );
+}
+
+async function runListCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      cursor: { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createDatasetsApiClient(context);
+  const response = await api.listDatasetsV1({
+    xRequestId: parseRequestId(parsed.values),
+    cursor: nonEmpty(parsed.values.cursor),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const items = (serial.items as Record<string, unknown>[]) ?? [];
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "dataset list",
+      ...serial,
+    },
+    {
+      title: "dataset list",
+      notes: [`requestId: ${response.requestId}`, `nextCursor: ${response.nextCursor ?? "-"}`],
+      rows: items.map((dataset) => parseDatasetTable(dataset)),
+      columns: ["id", "filename", "contentType", "sizeBytes", "status", "providerDataId", "updatedAt"],
+      emptyMessage: "No datasets found.",
+    },
+  );
+}
+
+function emitDatasetHelp(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "dataset",
+    usage: [
+      "trading-cli dataset upload init --filename btc.csv --content-type text/csv --size-bytes 1024 [--output json|table]",
+      "trading-cli dataset upload init --input <init-upload.json> [--output json|table]",
+      "trading-cli dataset upload complete --dataset-id <id> [--upload-token <token>] [--output json|table]",
+      "trading-cli dataset validate --dataset-id <id> [--column-mapping-json '{\"timestamp\":\"ts\"}'] [--output json|table]",
+      "trading-cli dataset transform --dataset-id <id> --frequency 1h [--output json|table]",
+      "trading-cli dataset publish --dataset-id <id> [--mode explicit|just_in_time] [--output json|table]",
+      "trading-cli dataset get --dataset-id <id> [--output json|table]",
+      "trading-cli dataset status --dataset-id <id> [--output json|table]",
+      "trading-cli dataset list [--cursor <token>] [--output json|table]",
+    ],
+  });
+}
+
+export async function runDatasetCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    emitDatasetHelp(context);
+    return;
+  }
+
+  if (subcommand === "upload") {
+    const uploadSubcommand = args[1];
+    if (!uploadSubcommand || uploadSubcommand === "--help" || uploadSubcommand === "-h") {
+      context.emit({
+        status: "ok",
+        command: "dataset upload",
+        usage: [
+          "trading-cli dataset upload init --filename <file> --content-type <mime> --size-bytes <bytes>",
+          "trading-cli dataset upload complete --dataset-id <id> [--upload-token <token>]",
+        ],
+      });
+      return;
+    }
+    if (uploadSubcommand === "init") {
+      await runUploadInitCommand(args.slice(2), context);
+      return;
+    }
+    if (uploadSubcommand === "complete") {
+      await runUploadCompleteCommand(args.slice(2), context);
+      return;
+    }
+    throw new Error(`Unknown dataset upload subcommand '${uploadSubcommand}'. Use 'init' or 'complete'.`);
+  }
+
+  if (subcommand === "init") {
+    await runUploadInitCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "complete") {
+    await runUploadCompleteCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "validate") {
+    await runValidateCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "transform") {
+    await runTransformCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "publish") {
+    await runPublishCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "get") {
+    await runGetOrStatusCommand(args.slice(1), context, "dataset get");
+    return;
+  }
+  if (subcommand === "status") {
+    await runGetOrStatusCommand(args.slice(1), context, "dataset status");
+    return;
+  }
+  if (subcommand === "list") {
+    await runListCommand(args.slice(1), context);
+    return;
+  }
+
+  throw new Error(
+    `Unknown dataset subcommand '${subcommand}'. Use 'upload', 'validate', 'transform', 'publish', 'get', 'status', or 'list'.`,
+  );
+}

--- a/tests/smoke/dataset-cli.test.ts
+++ b/tests/smoke/dataset-cli.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { run } from "../../src/cli";
+
+type RecordedRequest = {
+  path: string;
+  method: string;
+  headers: Headers;
+  body?: unknown;
+};
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+const ORIGINAL_ERROR = console.error;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  console.log = ORIGINAL_LOG;
+  console.error = ORIGINAL_ERROR;
+  delete process.env.PLATFORM_API_BASE_URL;
+  delete process.env.PLATFORM_API_BEARER_TOKEN;
+  delete process.env.PLATFORM_API_TOKEN;
+  delete process.env.PLATFORM_API_KEY;
+});
+
+describe("dataset lifecycle command group", () => {
+  test("maps full lifecycle to canonical dataset endpoints", async () => {
+    const requests: RecordedRequest[] = [];
+    const logs: string[] = [];
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-dataset-001";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const dataset: {
+      id: string;
+      filename: string;
+      contentType: string;
+      sizeBytes: number;
+      status: string;
+      providerDataId: string | null;
+      uploadUrl: string;
+      createdAt: string;
+      updatedAt: string;
+    } = {
+      id: "dataset-001",
+      filename: "btc-1h.csv",
+      contentType: "text/csv",
+      sizeBytes: 1024,
+      status: "uploading",
+      providerDataId: null,
+      uploadUrl: "https://uploads.local/dataset-001",
+      createdAt: "2026-03-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ path: url.pathname, method, headers, body });
+
+      if (url.pathname === "/v1/datasets/uploads:init" && method === "POST") {
+        return jsonResponse({
+          requestId: "req-dataset-init-001",
+          datasetId: "dataset-001",
+          uploadUrl: "https://uploads.local/dataset-001",
+          status: "uploading",
+        });
+      }
+
+      if (url.pathname === "/v1/datasets/dataset-001/uploads:complete" && method === "POST") {
+        dataset.status = "uploaded";
+        dataset.updatedAt = "2026-03-01T00:01:00Z";
+        return jsonResponse({
+          requestId: "req-dataset-complete-001",
+          dataset,
+        });
+      }
+
+      if (url.pathname === "/v1/datasets/dataset-001/validate" && method === "POST") {
+        dataset.status = "validating";
+        dataset.updatedAt = "2026-03-01T00:02:00Z";
+        return jsonResponse({
+          requestId: "req-dataset-validate-001",
+          dataset,
+        });
+      }
+
+      if (url.pathname === "/v1/datasets/dataset-001/transform/candles" && method === "POST") {
+        dataset.status = "ready";
+        dataset.updatedAt = "2026-03-01T00:03:00Z";
+        dataset.providerDataId = "provider-dataset-001";
+        return jsonResponse({
+          requestId: "req-dataset-transform-001",
+          dataset,
+        });
+      }
+
+      if (url.pathname === "/v1/datasets/dataset-001/publish/lona" && method === "POST") {
+        dataset.status = "published_lona";
+        dataset.updatedAt = "2026-03-01T00:04:00Z";
+        return jsonResponse({
+          requestId: "req-dataset-publish-001",
+          dataset,
+        });
+      }
+
+      if (url.pathname === "/v1/datasets/dataset-001" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-dataset-get-001",
+          dataset,
+        });
+      }
+
+      if (url.pathname === "/v1/datasets" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-dataset-list-001",
+          items: [dataset],
+          nextCursor: null,
+        });
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "dataset",
+          "upload",
+          "init",
+          "--filename",
+          "btc-1h.csv",
+          "--content-type",
+          "text/csv",
+          "--size-bytes",
+          "1024",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "dataset",
+          "upload",
+          "complete",
+          "--dataset-id",
+          "dataset-001",
+          "--upload-token",
+          "upload-token-001",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "dataset",
+          "validate",
+          "--dataset-id",
+          "dataset-001",
+          "--column-mapping-json",
+          "{\"timestamp\":\"ts\"}",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "dataset",
+          "transform",
+          "--dataset-id",
+          "dataset-001",
+          "--frequency",
+          "1h",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "dataset",
+          "publish",
+          "--dataset-id",
+          "dataset-001",
+          "--mode",
+          "explicit",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "dataset", "get", "--dataset-id", "dataset-001"],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "dataset", "status", "--dataset-id", "dataset-001"],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "dataset", "list"], fetchMock)).toBe(0);
+
+    expect(requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "POST /v1/datasets/uploads:init",
+      "POST /v1/datasets/dataset-001/uploads:complete",
+      "POST /v1/datasets/dataset-001/validate",
+      "POST /v1/datasets/dataset-001/transform/candles",
+      "POST /v1/datasets/dataset-001/publish/lona",
+      "GET /v1/datasets/dataset-001",
+      "GET /v1/datasets/dataset-001",
+      "GET /v1/datasets",
+    ]);
+
+    for (const request of requests) {
+      expect(request.headers.get("X-Request-Id") ?? "").toContain("req-dataset-");
+    }
+
+    const initPayload = JSON.parse(logs[0] ?? "{}") as { command: string; status: string };
+    const statusPayload = JSON.parse(logs[6] ?? "{}") as { command: string; dataset: { status: string } };
+    expect(initPayload.command).toBe("dataset upload init");
+    expect(initPayload.status).toBe("ok");
+    expect(statusPayload.command).toBe("dataset status");
+    expect(statusPayload.dataset.status).toBe("published_lona");
+  });
+
+  test("validates required args pre-flight", async () => {
+    const errors: string[] = [];
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-dataset-002";
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    const exitCode = await run(["bun", "src/cli.ts", "dataset", "transform", "--dataset-id", "dataset-001"]);
+    expect(exitCode).toBe(1);
+
+    const envelope = JSON.parse(errors.at(-1) ?? "{}") as { status: string; message: string };
+    expect(envelope.status).toBe("error");
+    expect(envelope.message).toContain("--frequency is required");
+  });
+});


### PR DESCRIPTION
## Summary
- implement Phase 2 DATASET lane command group for lifecycle parity
- add canonical SDK routing for dataset lifecycle operations via `DatasetsApi`
- add deterministic `--output json|table` behavior across dataset commands
- add required pre-flight argument validation for lifecycle actions

## Commands
- `dataset upload init` (alias: `dataset init`)
- `dataset upload complete` (alias: `dataset complete`)
- `dataset validate`
- `dataset transform`
- `dataset publish`
- `dataset get`
- `dataset status`
- `dataset list`

## Contract alignment
- request-id support (`--request-id`) is implemented for all dataset calls
- idempotency flags are not added because `DatasetsApi` operations in the canonical contract do not expose idempotency headers
- routes are fully SDK-driven (including `uploads:init` / `uploads:complete` contract paths)

## Tests
- added `tests/smoke/dataset-cli.test.ts` lifecycle smoke coverage:
  - init -> complete -> validate -> transform -> publish -> get/status/list
  - pre-flight validation failure for missing required args

## Required validation evidence
- `bun install --frozen-lockfile` ✅
- `bun run build` ✅
- `bun test` ✅ (`27 pass, 2 skip, 0 fail`)
- `npm pack --dry-run` ✅
- `bun run sdk:drift` ✅
- `bun run sdk:drift --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml` ✅

## Tracking
- Closes #23
- Refs #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI surface area that drives multiple Platform API dataset lifecycle endpoints; mistakes could lead to incorrect request payloads/headers or confusing operator output. Risk is mitigated by SDK-driven routing and new smoke tests covering the full command flow and pre-flight validation.
> 
> **Overview**
> Adds a new top-level `dataset` command group to the CLI, wiring `upload init|complete`, `validate`, `transform`, `publish`, `get`, `status`, and `list` subcommands to the canonical `DatasetsApi` endpoints with consistent `--request-id` handling.
> 
> Implements deterministic `--output json|table` formatting (including table rendering for common dataset fields) and pre-flight argument validation for required flags (e.g., `--dataset-id`, `--frequency`).
> 
> Adds smoke tests that mock `fetch` to verify the end-to-end lifecycle hits the expected REST paths and emits request IDs, plus a negative test for missing required args.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c2da2e8af3f334e432d00ee395c17b95842a7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements Phase 2 dataset lifecycle command group with 8 new commands (`init`, `complete`, `validate`, `transform`, `publish`, `get`, `status`, `list`) using canonical SDK routing via `DatasetsApi`.

**Key changes:**
- Added dataset command routing in `cli.ts` following existing patterns
- Created `dataset-command.ts` with full lifecycle implementation
- Implemented deterministic `--output json|table` behavior across all commands
- Added pre-flight argument validation for required parameters
- Included comprehensive smoke tests covering full lifecycle and error scenarios
- Request-ID support implemented consistently across all dataset operations

**Minor issue:**
- Unused `parseCsv` helper function in `dataset-command.ts`

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor cleanup recommended
- Well-structured implementation following existing patterns with comprehensive test coverage; only issue is unused helper function
- No files require special attention - only minor dead code cleanup in `src/dataset-command.ts`

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli.ts | Added dataset command routing and help text - follows existing patterns |
| src/dataset-command.ts | New file implementing 8 dataset lifecycle commands with SDK integration; includes unused `parseCsv` function |
| tests/smoke/dataset-cli.test.ts | Comprehensive smoke tests covering full lifecycle and pre-flight validation |

</details>


</details>


<sub>Last reviewed commit: 35c2da2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->