### PR TITLE
Phase 2 SHARED: shared-validation, invite lifecycle, and conversations CLI parity

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { formatReviewRunError, runReviewRunCommand } from "./review-run-command"
 import { runValidationBotCommand } from "./validation-bot-command";
 import { runCoreCommand } from "./core-command";
 import { runDatasetCommand } from "./dataset-command";
+import { runSharedCommand } from "./shared-command";
 
 const BLOCKED_PROVIDER_HOST_HINTS = [
   "lona",
@@ -116,6 +117,10 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
         "order create|get|list|cancel",
         "dataset upload init|complete",
         "dataset validate|transform|publish|get|status|list",
+        "shared-validation shared-with-me|run|artifact|review-comment|review-decision",
+        "invite create|list|accept|revoke",
+        "conversation session create|get",
+        "conversation turn create",
       ],
     });
     return 0;
@@ -166,12 +171,23 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
       return 0;
     }
 
+    if (
+      args[0] === "shared-validation" ||
+      args[0] === "invite" ||
+      args[0] === "conversation" ||
+      args[0] === "conversations"
+    ) {
+      await runSharedCommand(args, context);
+      return 0;
+    }
+
     emitError({
       status: "error",
       message:
         `Unknown command '${args[0]}'. Use 'review-run', 'validation run', ` +
         "'register', 'key', 'bot', 'research', 'strategy', 'backtest', " +
-        "'deploy', 'portfolio', 'order', or 'dataset'.",
+        "'deploy', 'portfolio', 'order', 'dataset', 'shared-validation', " +
+        "'invite', or 'conversation'.",
       command: args,
       target: baseUrl,
     });

--- a/src/shared-command.ts
+++ b/src/shared-command.ts
@@ -1,0 +1,1091 @@
+import { parseArgs } from "node:util";
+
+import {
+  type CommandContext,
+  deriveIdempotencyKey,
+  deriveRequestId,
+  formatTable,
+  nonEmpty,
+  parseJsonFile,
+  parseOutputMode,
+  toSerializable,
+  type OutputMode,
+  type TableRow,
+} from "./command-utils";
+import {
+  ConversationChannel,
+  ConversationRole,
+  ValidationDecision,
+  ValidationReviewDecisionAction,
+  ValidationRunStatus,
+  ValidationSharePermission,
+  type AcceptValidationInviteRequest,
+  type CreateConversationSessionRequest,
+  type CreateConversationTurnRequest,
+  type CreateValidationInviteRequest,
+  type CreateValidationReviewCommentRequest,
+  type CreateValidationReviewDecisionRequest,
+} from "./generated/trade-nexus-sdk";
+import {
+  createConversationsApiClient,
+  createSharedValidationApiClient,
+  createValidationApiClient,
+} from "./platform-api-sdk";
+
+type ParsedValues = ReturnType<typeof parseArgs>["values"];
+
+const SHARED_REQUEST_ID_PREFIX = "req-shared";
+const SHARED_IDEMPOTENCY_PREFIX = "idem-shared";
+
+const RUN_STATUSES = new Set<string>(Object.values(ValidationRunStatus));
+const FINAL_DECISIONS = new Set<string>(Object.values(ValidationDecision));
+const PERMISSIONS = new Set<string>(Object.values(ValidationSharePermission));
+const REVIEW_ACTIONS = new Set<string>(Object.values(ValidationReviewDecisionAction));
+const CHANNELS = new Set<string>(Object.values(ConversationChannel));
+const ROLES = new Set<string>(Object.values(ConversationRole));
+
+type TableOutput = {
+  title?: string;
+  notes?: string[];
+  rows: TableRow[];
+  columns: string[];
+  emptyMessage?: string;
+};
+
+function parseRequestId(values: ParsedValues): string {
+  return deriveRequestId(SHARED_REQUEST_ID_PREFIX, nonEmpty(values["request-id"]));
+}
+
+function parseIdempotencyKey(values: ParsedValues): string {
+  return deriveIdempotencyKey(
+    SHARED_IDEMPOTENCY_PREFIX,
+    nonEmpty(values["idempotency-key"]),
+  );
+}
+
+function parseCsv(value: unknown): string[] {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function parseEnum<T extends string>(value: unknown, label: string, set: Set<string>): T | undefined {
+  const raw = nonEmpty(value)?.toLowerCase();
+  if (!raw) {
+    return undefined;
+  }
+  if (!set.has(raw)) {
+    throw new Error(`${label} must be one of: ${Array.from(set).join(", ")}.`);
+  }
+  return raw as T;
+}
+
+function parseLimit(value: unknown): number | undefined {
+  const raw = nonEmpty(value);
+  if (!raw) {
+    return undefined;
+  }
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("--limit must be an integer between 1 and 100.");
+  }
+  return limit;
+}
+
+function parseMetadataJson(raw: unknown, label: string): Record<string, unknown> | undefined {
+  const value = nonEmpty(raw);
+  if (!value) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error(
+      `Unable to parse ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function emitOutput(
+  context: CommandContext,
+  output: OutputMode,
+  payload: unknown,
+  table?: TableOutput,
+): void {
+  const serial = toSerializable(payload);
+  if (output === "json") {
+    context.emit(serial);
+    return;
+  }
+  if (!table) {
+    console.log(JSON.stringify(serial, null, 2));
+    return;
+  }
+
+  const lines: string[] = [];
+  if (table.title) {
+    lines.push(table.title);
+  }
+  if (table.notes && table.notes.length > 0) {
+    lines.push(...table.notes);
+  }
+  if (table.rows.length === 0) {
+    lines.push(table.emptyMessage ?? "(no rows)");
+  } else {
+    lines.push(formatTable(table.rows, table.columns));
+  }
+  console.log(lines.join("\n"));
+}
+
+function buildRunTableRow(run: Record<string, unknown>): TableRow {
+  return {
+    runId: run.id as string,
+    status: run.status as string,
+    profile: run.profile as string,
+    finalDecision: run.finalDecision as string,
+    createdAt: run.createdAt as string,
+    updatedAt: run.updatedAt as string,
+  };
+}
+
+function buildInviteTableRow(invite: Record<string, unknown>): TableRow {
+  return {
+    id: invite.id as string,
+    runId: invite.runId as string,
+    email: invite.email as string,
+    permission: invite.permission as string,
+    status: invite.status as string,
+    createdAt: invite.createdAt as string,
+    expiresAt: invite.expiresAt as string | null | undefined,
+  };
+}
+
+function buildConversationSessionRow(session: Record<string, unknown>): TableRow {
+  return {
+    id: session.id as string,
+    channel: session.channel as string,
+    status: session.status as string,
+    topic: session.topic as string | null | undefined,
+    lastTurnAt: session.lastTurnAt as string | null | undefined,
+    updatedAt: session.updatedAt as string,
+  };
+}
+
+function buildConversationTurnRow(turn: Record<string, unknown>): TableRow {
+  const suggestions = (turn.suggestions as unknown[]) ?? [];
+  return {
+    id: turn.id as string,
+    sessionId: turn.sessionId as string,
+    role: turn.role as string,
+    message: turn.message as string,
+    suggestions: suggestions.length,
+    createdAt: turn.createdAt as string,
+  };
+}
+
+async function runSharedWithMeCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      status: { type: "string" },
+      "final-decision": { type: "string" },
+      permission: { type: "string" },
+      cursor: { type: "string" },
+      limit: { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const status = parseEnum<ValidationRunStatus>(parsed.values.status, "--status", RUN_STATUSES);
+  const finalDecision = parseEnum<ValidationDecision>(
+    parsed.values["final-decision"],
+    "--final-decision",
+    FINAL_DECISIONS,
+  );
+  const permission = parseEnum<ValidationSharePermission>(
+    parsed.values.permission,
+    "--permission",
+    PERMISSIONS,
+  );
+  const limit = parseLimit(parsed.values.limit);
+  const output = parseOutputMode(parsed.values.output);
+
+  const api = createSharedValidationApiClient(context);
+  const response = await api.listValidationRunsSharedWithMeV2({
+    xRequestId: parseRequestId(parsed.values),
+    status,
+    finalDecision,
+    permission,
+    cursor: nonEmpty(parsed.values.cursor),
+    limit,
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const items = (serial.items as Record<string, unknown>[]) ?? [];
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "shared-validation shared-with-me",
+      ...serial,
+    },
+    {
+      title: "shared-validation shared-with-me",
+      notes: [
+        `requestId: ${response.requestId}`,
+        `nextCursor: ${response.nextCursor ?? "-"}`,
+      ],
+      rows: items.map((item) => ({
+        runId: item.runId as string,
+        permission: item.permission as string,
+        status: item.status as string,
+        profile: item.profile as string,
+        finalDecision: item.finalDecision as string,
+        ownerUserId: item.ownerUserId as string,
+        updatedAt: item.updatedAt as string,
+      })),
+      columns: [
+        "runId",
+        "permission",
+        "status",
+        "profile",
+        "finalDecision",
+        "ownerUserId",
+        "updatedAt",
+      ],
+      emptyMessage: "No shared validation runs found.",
+    },
+  );
+}
+
+async function runSharedRunGetCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "run-id": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const runId = nonEmpty(parsed.values["run-id"]);
+  if (!runId) {
+    throw new Error("--run-id is required.");
+  }
+
+  const output = parseOutputMode(parsed.values.output);
+  const api = createValidationApiClient(context);
+  const response = await api.getValidationRunV2({
+    runId,
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const run = serial.run as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "shared-validation run",
+      ...serial,
+    },
+    {
+      title: "shared-validation run",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildRunTableRow(run)],
+      columns: ["runId", "status", "profile", "finalDecision", "createdAt", "updatedAt"],
+    },
+  );
+}
+
+async function runSharedArtifactCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "run-id": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const runId = nonEmpty(parsed.values["run-id"]);
+  if (!runId) {
+    throw new Error("--run-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createValidationApiClient(context);
+  const response = await api.getValidationRunArtifactV2({
+    runId,
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "shared-validation artifact",
+      ...serial,
+    },
+    {
+      title: "shared-validation artifact",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [
+        {
+          artifactType: serial.artifactType as string,
+          runId,
+        },
+      ],
+      columns: ["runId", "artifactType"],
+    },
+  );
+}
+
+function parseReviewCommentRequest(values: ParsedValues): CreateValidationReviewCommentRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateValidationReviewCommentRequest>(
+      inputPath,
+      "shared-validation review comment payload",
+    );
+  }
+  const body = nonEmpty(values.body);
+  if (!body) {
+    throw new Error("--body is required when --input is not provided.");
+  }
+  const evidenceRefs = parseCsv(values["evidence-refs"]);
+  return {
+    body,
+    ...(evidenceRefs.length > 0 ? { evidenceRefs } : {}),
+  };
+}
+
+function parseReviewDecisionRequest(values: ParsedValues): CreateValidationReviewDecisionRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateValidationReviewDecisionRequest>(
+      inputPath,
+      "shared-validation review decision payload",
+    );
+  }
+
+  const action = parseEnum<ValidationReviewDecisionAction>(
+    values.action,
+    "--action",
+    REVIEW_ACTIONS,
+  );
+  const decision = parseEnum<ValidationDecision>(
+    values.decision,
+    "--decision",
+    FINAL_DECISIONS,
+  );
+  const reason = nonEmpty(values.reason);
+
+  if (!action) {
+    throw new Error("--action is required when --input is not provided.");
+  }
+  if (!decision) {
+    throw new Error("--decision is required when --input is not provided.");
+  }
+  if (!reason) {
+    throw new Error("--reason is required when --input is not provided.");
+  }
+  const evidenceRefs = parseCsv(values["evidence-refs"]);
+  return {
+    action,
+    decision,
+    reason,
+    ...(evidenceRefs.length > 0 ? { evidenceRefs } : {}),
+  };
+}
+
+async function runSharedReviewCommentCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "run-id": { type: "string" },
+      input: { type: "string" },
+      body: { type: "string" },
+      "evidence-refs": { type: "string" },
+      "request-id": { type: "string" },
+      "idempotency-key": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const runId = nonEmpty(parsed.values["run-id"]);
+  if (!runId) {
+    throw new Error("--run-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createSharedValidationApiClient(context);
+  const response = await api.createSharedValidationReviewCommentV2({
+    runId,
+    idempotencyKey: parseIdempotencyKey(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+    createValidationReviewCommentRequest: parseReviewCommentRequest(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const comment = serial.comment as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "shared-validation review-comment",
+      ...serial,
+    },
+    {
+      title: "shared-validation review-comment",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [
+        {
+          runId: serial.runId as string,
+          commentId: comment.id as string,
+          accepted: serial.commentAccepted as boolean,
+        },
+      ],
+      columns: ["runId", "commentId", "accepted"],
+    },
+  );
+}
+
+async function runSharedReviewDecisionCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "run-id": { type: "string" },
+      input: { type: "string" },
+      action: { type: "string" },
+      decision: { type: "string" },
+      reason: { type: "string" },
+      "evidence-refs": { type: "string" },
+      "request-id": { type: "string" },
+      "idempotency-key": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const runId = nonEmpty(parsed.values["run-id"]);
+  if (!runId) {
+    throw new Error("--run-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createSharedValidationApiClient(context);
+  const response = await api.createSharedValidationReviewDecisionV2({
+    runId,
+    idempotencyKey: parseIdempotencyKey(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+    createValidationReviewDecisionRequest: parseReviewDecisionRequest(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const decision = serial.decision as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "shared-validation review-decision",
+      ...serial,
+    },
+    {
+      title: "shared-validation review-decision",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [
+        {
+          runId: serial.runId as string,
+          decisionId: decision.id as string,
+          accepted: serial.decisionAccepted as boolean,
+        },
+      ],
+      columns: ["runId", "decisionId", "accepted"],
+    },
+  );
+}
+
+function emitSharedValidationHelp(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "shared-validation",
+    usage: [
+      "trading-cli shared-validation shared-with-me [--permission view|review] [--status queued|running|completed|failed] [--final-decision pass|conditional_pass|fail] [--output json|table]",
+      "trading-cli shared-validation run --run-id <id> [--output json|table]",
+      "trading-cli shared-validation artifact --run-id <id> [--output json|table]",
+      "trading-cli shared-validation review-comment --run-id <id> --body <text> [--evidence-refs <csv>] [--output json|table]",
+      "trading-cli shared-validation review-decision --run-id <id> --action approve|reject --decision pass|conditional_pass|fail --reason <text> [--output json|table]",
+    ],
+  });
+}
+
+async function runSharedValidationCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    emitSharedValidationHelp(context);
+    return;
+  }
+
+  if (subcommand === "shared-with-me" || subcommand === "list") {
+    await runSharedWithMeCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "run") {
+    await runSharedRunGetCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "artifact") {
+    await runSharedArtifactCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "review-comment" || subcommand === "comment") {
+    await runSharedReviewCommentCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "review-decision" || subcommand === "decision") {
+    await runSharedReviewDecisionCommand(args.slice(1), context);
+    return;
+  }
+
+  throw new Error(
+    `Unknown shared-validation subcommand '${subcommand}'. Use 'shared-with-me', 'run', 'artifact', 'review-comment', or 'review-decision'.`,
+  );
+}
+
+function parseCreateInvitePayload(values: ParsedValues): CreateValidationInviteRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateValidationInviteRequest>(inputPath, "invite create payload");
+  }
+
+  const email = nonEmpty(values.email);
+  if (!email) {
+    throw new Error("--email is required when --input is not provided.");
+  }
+  const permission = parseEnum<ValidationSharePermission>(
+    values.permission,
+    "--permission",
+    PERMISSIONS,
+  );
+  const message = nonEmpty(values.message);
+  const expiresAtRaw = nonEmpty(values["expires-at"]);
+  let expiresAt: Date | undefined;
+  if (expiresAtRaw) {
+    expiresAt = new Date(expiresAtRaw);
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new Error("--expires-at must be an ISO timestamp.");
+    }
+  }
+
+  return {
+    email,
+    ...(permission ? { permission } : {}),
+    ...(message ? { message } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+}
+
+function parseAcceptInvitePayload(values: ParsedValues): AcceptValidationInviteRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<AcceptValidationInviteRequest>(inputPath, "invite accept payload");
+  }
+
+  const acceptedEmail = nonEmpty(values["accepted-email"]);
+  if (!acceptedEmail) {
+    throw new Error("--accepted-email is required when --input is not provided.");
+  }
+  const loginSessionId = nonEmpty(values["login-session-id"]);
+  return {
+    acceptedEmail,
+    ...(loginSessionId ? { loginSessionId } : {}),
+  };
+}
+
+async function runInviteCreateCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "run-id": { type: "string" },
+      input: { type: "string" },
+      email: { type: "string" },
+      permission: { type: "string" },
+      message: { type: "string" },
+      "expires-at": { type: "string" },
+      "request-id": { type: "string" },
+      "idempotency-key": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  const runId = nonEmpty(parsed.values["run-id"]);
+  if (!runId) {
+    throw new Error("--run-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createValidationApiClient(context);
+  const response = await api.createValidationRunInviteV2({
+    runId,
+    idempotencyKey: parseIdempotencyKey(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+    createValidationInviteRequest: parseCreateInvitePayload(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const invite = serial.invite as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "invite create",
+      ...serial,
+    },
+    {
+      title: "invite create",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildInviteTableRow(invite)],
+      columns: ["id", "runId", "email", "permission", "status", "createdAt", "expiresAt"],
+    },
+  );
+}
+
+async function runInviteListCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "run-id": { type: "string" },
+      cursor: { type: "string" },
+      limit: { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const runId = nonEmpty(parsed.values["run-id"]);
+  if (!runId) {
+    throw new Error("--run-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createValidationApiClient(context);
+  const response = await api.listValidationRunInvitesV2({
+    runId,
+    xRequestId: parseRequestId(parsed.values),
+    cursor: nonEmpty(parsed.values.cursor),
+    limit: parseLimit(parsed.values.limit),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const items = (serial.items as Record<string, unknown>[]) ?? [];
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "invite list",
+      ...serial,
+    },
+    {
+      title: "invite list",
+      notes: [`requestId: ${response.requestId}`, `nextCursor: ${response.nextCursor ?? "-"}`],
+      rows: items.map((invite) => buildInviteTableRow(invite)),
+      columns: ["id", "runId", "email", "permission", "status", "createdAt", "expiresAt"],
+      emptyMessage: "No invites found.",
+    },
+  );
+}
+
+async function runInviteAcceptCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "invite-id": { type: "string" },
+      input: { type: "string" },
+      "accepted-email": { type: "string" },
+      "login-session-id": { type: "string" },
+      "request-id": { type: "string" },
+      "idempotency-key": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const inviteId = nonEmpty(parsed.values["invite-id"]);
+  if (!inviteId) {
+    throw new Error("--invite-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createValidationApiClient(context);
+  const response = await api.acceptValidationInviteOnLoginV2({
+    inviteId,
+    idempotencyKey: parseIdempotencyKey(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+    acceptValidationInviteRequest: parseAcceptInvitePayload(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const invite = serial.invite as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "invite accept",
+      ...serial,
+    },
+    {
+      title: "invite accept",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildInviteTableRow(invite)],
+      columns: ["id", "runId", "email", "permission", "status", "createdAt", "expiresAt"],
+    },
+  );
+}
+
+async function runInviteRevokeCommand(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "invite-id": { type: "string" },
+      "request-id": { type: "string" },
+      "idempotency-key": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const inviteId = nonEmpty(parsed.values["invite-id"]);
+  if (!inviteId) {
+    throw new Error("--invite-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createValidationApiClient(context);
+  const response = await api.revokeValidationInviteV2({
+    inviteId,
+    idempotencyKey: parseIdempotencyKey(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const invite = serial.invite as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "invite revoke",
+      ...serial,
+    },
+    {
+      title: "invite revoke",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildInviteTableRow(invite)],
+      columns: ["id", "runId", "email", "permission", "status", "createdAt", "expiresAt"],
+    },
+  );
+}
+
+function emitInviteHelp(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "invite",
+    usage: [
+      "trading-cli invite create --run-id <id> --email <email> [--permission view|review] [--message <text>] [--expires-at <iso>] [--output json|table]",
+      "trading-cli invite list --run-id <id> [--limit 20] [--cursor <token>] [--output json|table]",
+      "trading-cli invite accept --invite-id <id> --accepted-email <email> [--login-session-id <id>] [--output json|table]",
+      "trading-cli invite revoke --invite-id <id> [--output json|table]",
+    ],
+  });
+}
+
+async function runInviteCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    emitInviteHelp(context);
+    return;
+  }
+  if (subcommand === "create") {
+    await runInviteCreateCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "list") {
+    await runInviteListCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "accept") {
+    await runInviteAcceptCommand(args.slice(1), context);
+    return;
+  }
+  if (subcommand === "revoke") {
+    await runInviteRevokeCommand(args.slice(1), context);
+    return;
+  }
+  throw new Error(`Unknown invite subcommand '${subcommand}'. Use 'create', 'list', 'accept', or 'revoke'.`);
+}
+
+function parseCreateSessionPayload(values: ParsedValues): CreateConversationSessionRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateConversationSessionRequest>(inputPath, "conversation session payload");
+  }
+  const channel = parseEnum<ConversationChannel>(values.channel, "--channel", CHANNELS);
+  if (!channel) {
+    throw new Error("--channel is required when --input is not provided.");
+  }
+  const topic = nonEmpty(values.topic);
+  const metadata = parseMetadataJson(values["metadata-json"], "--metadata-json");
+  return {
+    channel,
+    ...(topic ? { topic } : {}),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function parseCreateTurnPayload(values: ParsedValues): CreateConversationTurnRequest {
+  const inputPath = nonEmpty(values.input);
+  if (inputPath) {
+    return parseJsonFile<CreateConversationTurnRequest>(inputPath, "conversation turn payload");
+  }
+  const role = parseEnum<ConversationRole>(values.role, "--role", ROLES);
+  const message = nonEmpty(values.message);
+  if (!role) {
+    throw new Error("--role is required when --input is not provided.");
+  }
+  if (!message) {
+    throw new Error("--message is required when --input is not provided.");
+  }
+  const metadata = parseMetadataJson(values["metadata-json"], "--metadata-json");
+  return {
+    role,
+    message,
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+async function runConversationSessionCreate(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      input: { type: "string" },
+      channel: { type: "string" },
+      topic: { type: "string" },
+      "metadata-json": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const output = parseOutputMode(parsed.values.output);
+  const api = createConversationsApiClient(context);
+  const response = await api.createConversationSessionV2({
+    createConversationSessionRequest: parseCreateSessionPayload(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const session = serial.session as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "conversation session create",
+      ...serial,
+    },
+    {
+      title: "conversation session create",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildConversationSessionRow(session)],
+      columns: ["id", "channel", "status", "topic", "lastTurnAt", "updatedAt"],
+    },
+  );
+}
+
+async function runConversationSessionGet(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "session-id": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const sessionId = nonEmpty(parsed.values["session-id"]);
+  if (!sessionId) {
+    throw new Error("--session-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createConversationsApiClient(context);
+  const response = await api.getConversationSessionV2({
+    sessionId,
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const session = serial.session as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "conversation session get",
+      ...serial,
+    },
+    {
+      title: "conversation session get",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildConversationSessionRow(session)],
+      columns: ["id", "channel", "status", "topic", "lastTurnAt", "updatedAt"],
+    },
+  );
+}
+
+async function runConversationTurnCreate(args: string[], context: CommandContext): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      "session-id": { type: "string" },
+      input: { type: "string" },
+      role: { type: "string" },
+      message: { type: "string" },
+      "metadata-json": { type: "string" },
+      "request-id": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  const sessionId = nonEmpty(parsed.values["session-id"]);
+  if (!sessionId) {
+    throw new Error("--session-id is required.");
+  }
+  const output = parseOutputMode(parsed.values.output);
+  const api = createConversationsApiClient(context);
+  const response = await api.createConversationTurnV2({
+    sessionId,
+    createConversationTurnRequest: parseCreateTurnPayload(parsed.values),
+    xRequestId: parseRequestId(parsed.values),
+  });
+
+  const serial = toSerializable(response) as Record<string, unknown>;
+  const turn = serial.turn as Record<string, unknown>;
+  emitOutput(
+    context,
+    output,
+    {
+      status: "ok",
+      command: "conversation turn create",
+      ...serial,
+    },
+    {
+      title: "conversation turn create",
+      notes: [`requestId: ${response.requestId}`],
+      rows: [buildConversationTurnRow(turn)],
+      columns: ["id", "sessionId", "role", "message", "suggestions", "createdAt"],
+    },
+  );
+}
+
+function emitConversationHelp(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "conversation",
+    usage: [
+      "trading-cli conversation session create --channel cli|web|openclaw [--topic <text>] [--metadata-json '{...}'] [--output json|table]",
+      "trading-cli conversation session get --session-id <id> [--output json|table]",
+      "trading-cli conversation turn create --session-id <id> --role user|assistant|system --message <text> [--metadata-json '{...}'] [--output json|table]",
+    ],
+  });
+}
+
+async function runConversationCommand(args: string[], context: CommandContext): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    emitConversationHelp(context);
+    return;
+  }
+
+  if (subcommand === "session") {
+    const action = args[1];
+    if (!action || action === "--help" || action === "-h") {
+      emitConversationHelp(context);
+      return;
+    }
+    if (action === "create") {
+      await runConversationSessionCreate(args.slice(2), context);
+      return;
+    }
+    if (action === "get") {
+      await runConversationSessionGet(args.slice(2), context);
+      return;
+    }
+    throw new Error(`Unknown conversation session subcommand '${action}'. Use 'create' or 'get'.`);
+  }
+
+  if (subcommand === "turn") {
+    const action = args[1];
+    if (action !== "create") {
+      throw new Error("conversation turn supports only 'create'.");
+    }
+    await runConversationTurnCreate(args.slice(2), context);
+    return;
+  }
+
+  throw new Error(`Unknown conversation subcommand '${subcommand}'. Use 'session' or 'turn'.`);
+}
+
+export async function runSharedCommand(args: string[], context: CommandContext): Promise<void> {
+  const group = args[0];
+  if (!group || group === "--help" || group === "-h") {
+    context.emit({
+      status: "ok",
+      command: "shared",
+      groups: ["shared-validation", "invite", "conversation"],
+    });
+    return;
+  }
+
+  if (group === "shared-validation") {
+    await runSharedValidationCommand(args.slice(1), context);
+    return;
+  }
+  if (group === "invite") {
+    await runInviteCommand(args.slice(1), context);
+    return;
+  }
+  if (group === "conversation" || group === "conversations") {
+    await runConversationCommand(args.slice(1), context);
+    return;
+  }
+
+  throw new Error(`Unsupported shared command group '${group}'.`);
+}

--- a/tests/smoke/shared-cli.test.ts
+++ b/tests/smoke/shared-cli.test.ts
@@ -1,0 +1,605 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { run } from "../../src/cli";
+
+type RecordedRequest = {
+  path: string;
+  method: string;
+  query: URLSearchParams;
+  headers: Headers;
+  body?: unknown;
+};
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+const ORIGINAL_ERROR = console.error;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  console.log = ORIGINAL_LOG;
+  console.error = ORIGINAL_ERROR;
+  delete process.env.PLATFORM_API_BASE_URL;
+  delete process.env.PLATFORM_API_BEARER_TOKEN;
+  delete process.env.PLATFORM_API_TOKEN;
+  delete process.env.PLATFORM_API_KEY;
+});
+
+describe("shared validation/invite/conversation command groups", () => {
+  test("shared-validation maps shared read/artifact/review actions", async () => {
+    const requests: RecordedRequest[] = [];
+    const logs: string[] = [];
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-shared-001";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ path: url.pathname, method, query: url.searchParams, headers, body });
+
+      if (url.pathname === "/v2/validation-sharing/runs/shared-with-me" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-shared-list-001",
+          items: [
+            {
+              runId: "run-001",
+              permission: "review",
+              status: "completed",
+              profile: "STANDARD",
+              finalDecision: "pass",
+              ownerUserId: "owner-001",
+              sharedAt: "2026-03-01T09:00:00Z",
+              createdAt: "2026-03-01T08:00:00Z",
+              updatedAt: "2026-03-01T09:00:00Z",
+            },
+          ],
+          nextCursor: null,
+        });
+      }
+
+      if (url.pathname === "/v2/validation-runs/run-001" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-shared-run-001",
+          run: {
+            id: "run-001",
+            status: "completed",
+            profile: "STANDARD",
+            schemaVersion: "validation-run.v1",
+            finalDecision: "pass",
+            createdAt: "2026-03-01T08:00:00Z",
+            updatedAt: "2026-03-01T09:00:00Z",
+          },
+        });
+      }
+
+      if (url.pathname === "/v2/validation-runs/run-001/artifact" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-shared-artifact-001",
+          artifactType: "validation_run",
+          artifact: {
+            schemaVersion: "validation-run.v1",
+            runId: "run-001",
+            createdAt: "2026-03-01T08:00:00Z",
+            requestId: "req-shared-run-001",
+            tenantId: "tenant-001",
+            userId: "user-001",
+            strategyRef: {
+              strategyId: "strat-001",
+              provider: "lona",
+              providerRefId: "provider-001",
+            },
+            inputs: {
+              prompt: "test",
+              requestedIndicators: ["ema"],
+              datasetIds: ["dataset-001"],
+              backtestReportRef: "blob://report",
+            },
+            outputs: {
+              strategyCodeRef: "blob://strategy",
+              backtestReportRef: "blob://report",
+              tradesRef: "blob://trades",
+              executionLogsRef: "blob://logs",
+              chartPayloadRef: "blob://chart",
+            },
+            deterministicChecks: {
+              indicatorFidelity: { status: "pass", missingIndicators: [] },
+              tradeCoherence: { status: "pass", violations: [] },
+              metricConsistency: { status: "pass", driftPct: 0 },
+            },
+            agentReview: { status: "pass", summary: "ok", findings: [] },
+            traderReview: { required: true, status: "requested", comments: [] },
+            policy: {
+              profile: "STANDARD",
+              blockMergeOnFail: true,
+              blockReleaseOnFail: true,
+              blockMergeOnAgentFail: true,
+              blockReleaseOnAgentFail: false,
+              requireTraderReview: true,
+              hardFailOnMissingIndicators: true,
+              failClosedOnEvidenceUnavailable: true,
+            },
+            finalDecision: "pass",
+          },
+        });
+      }
+
+      if (url.pathname === "/v2/validation-sharing/runs/run-001/comments" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-shared-comment-001",
+            runId: "run-001",
+            commentAccepted: true,
+            comment: {
+              id: "comment-001",
+              runId: "run-001",
+              body: "Looks good",
+              evidenceRefs: [],
+              createdByUserId: "reviewer-001",
+              createdByActorType: "human",
+              createdAt: "2026-03-01T09:30:00Z",
+            },
+          },
+          201,
+        );
+      }
+
+      if (url.pathname === "/v2/validation-sharing/runs/run-001/decisions" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-shared-decision-001",
+            runId: "run-001",
+            decisionAccepted: true,
+            decision: {
+              id: "decision-001",
+              runId: "run-001",
+              action: "approve",
+              decision: "pass",
+              reason: "meets criteria",
+              evidenceRefs: [],
+              createdByUserId: "reviewer-001",
+              createdByActorType: "human",
+              createdAt: "2026-03-01T09:31:00Z",
+            },
+          },
+          201,
+        );
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "shared-validation",
+          "shared-with-me",
+          "--permission",
+          "review",
+          "--status",
+          "completed",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "shared-validation", "run", "--run-id", "run-001"],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "shared-validation", "artifact", "--run-id", "run-001"],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "shared-validation",
+          "review-comment",
+          "--run-id",
+          "run-001",
+          "--body",
+          "Looks good",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "shared-validation",
+          "review-decision",
+          "--run-id",
+          "run-001",
+          "--action",
+          "approve",
+          "--decision",
+          "pass",
+          "--reason",
+          "meets criteria",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+
+    expect(requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /v2/validation-sharing/runs/shared-with-me",
+      "GET /v2/validation-runs/run-001",
+      "GET /v2/validation-runs/run-001/artifact",
+      "POST /v2/validation-sharing/runs/run-001/comments",
+      "POST /v2/validation-sharing/runs/run-001/decisions",
+    ]);
+
+    expect(requests[0]?.query.get("permission")).toBe("review");
+    expect(requests[0]?.query.get("status")).toBe("completed");
+    expect(requests[3]?.headers.get("Idempotency-Key")).toContain("idem-shared-");
+    expect(requests[4]?.headers.get("Idempotency-Key")).toContain("idem-shared-");
+
+    const payload = JSON.parse(logs[0] ?? "{}") as { command: string; status: string };
+    expect(payload.command).toBe("shared-validation shared-with-me");
+    expect(payload.status).toBe("ok");
+  });
+
+  test("invite lifecycle maps to canonical invite endpoints and validates permission semantics", async () => {
+    const requests: RecordedRequest[] = [];
+    const logs: string[] = [];
+    const errors: string[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-shared-002";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ path: url.pathname, method, query: url.searchParams, headers, body });
+
+      if (url.pathname === "/v2/validation-sharing/runs/run-001/invites" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-invite-create-001",
+            invite: {
+              id: "invite-001",
+              runId: "run-001",
+              email: "reviewer@example.com",
+              permission: "review",
+              status: "pending",
+              invitedByUserId: "owner-001",
+              invitedByActorType: "human",
+              createdAt: "2026-03-01T10:00:00Z",
+              expiresAt: null,
+              acceptedAt: null,
+              revokedAt: null,
+            },
+          },
+          201,
+        );
+      }
+
+      if (url.pathname === "/v2/validation-sharing/runs/run-001/invites" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-invite-list-001",
+          items: [
+            {
+              id: "invite-001",
+              runId: "run-001",
+              email: "reviewer@example.com",
+              permission: "review",
+              status: "pending",
+              invitedByUserId: "owner-001",
+              invitedByActorType: "human",
+              createdAt: "2026-03-01T10:00:00Z",
+              expiresAt: null,
+              acceptedAt: null,
+              revokedAt: null,
+            },
+          ],
+          nextCursor: null,
+        });
+      }
+
+      if (url.pathname === "/v2/validation-sharing/invites/invite-001/accept" && method === "POST") {
+        return jsonResponse({
+          requestId: "req-invite-accept-001",
+          invite: {
+            id: "invite-001",
+            runId: "run-001",
+            email: "reviewer@example.com",
+            permission: "review",
+            status: "accepted",
+            invitedByUserId: "owner-001",
+            invitedByActorType: "human",
+            createdAt: "2026-03-01T10:00:00Z",
+            expiresAt: null,
+            acceptedAt: "2026-03-01T10:05:00Z",
+            revokedAt: null,
+          },
+          share: {
+            id: "share-001",
+            runId: "run-001",
+            ownerUserId: "owner-001",
+            sharedWithEmail: "reviewer@example.com",
+            sharedWithUserId: "reviewer-001",
+            inviteId: "invite-001",
+            status: "active",
+            grantedAt: "2026-03-01T10:05:00Z",
+            revokedAt: null,
+          },
+        });
+      }
+
+      if (url.pathname === "/v2/validation-sharing/invites/invite-001/revoke" && method === "POST") {
+        return jsonResponse({
+          requestId: "req-invite-revoke-001",
+          invite: {
+            id: "invite-001",
+            runId: "run-001",
+            email: "reviewer@example.com",
+            permission: "review",
+            status: "revoked",
+            invitedByUserId: "owner-001",
+            invitedByActorType: "human",
+            createdAt: "2026-03-01T10:00:00Z",
+            expiresAt: null,
+            acceptedAt: null,
+            revokedAt: "2026-03-01T10:06:00Z",
+          },
+        });
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "invite",
+          "create",
+          "--run-id",
+          "run-001",
+          "--email",
+          "reviewer@example.com",
+          "--permission",
+          "review",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "invite", "list", "--run-id", "run-001", "--limit", "10"],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "invite",
+          "accept",
+          "--invite-id",
+          "invite-001",
+          "--accepted-email",
+          "reviewer@example.com",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "invite", "revoke", "--invite-id", "invite-001"],
+        fetchMock,
+      ),
+    ).toBe(0);
+
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "invite",
+          "create",
+          "--run-id",
+          "run-001",
+          "--email",
+          "bad@example.com",
+          "--permission",
+          "admin",
+        ],
+        fetchMock,
+      ),
+    ).toBe(1);
+
+    expect(requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "POST /v2/validation-sharing/runs/run-001/invites",
+      "GET /v2/validation-sharing/runs/run-001/invites",
+      "POST /v2/validation-sharing/invites/invite-001/accept",
+      "POST /v2/validation-sharing/invites/invite-001/revoke",
+    ]);
+    expect(requests[0]?.headers.get("Idempotency-Key")).toContain("idem-shared-");
+    expect(requests[2]?.headers.get("Idempotency-Key")).toContain("idem-shared-");
+    expect(requests[3]?.headers.get("Idempotency-Key")).toContain("idem-shared-");
+
+    const errorPayload = JSON.parse(errors.at(-1) ?? "{}") as { status: string; message: string };
+    expect(errorPayload.status).toBe("error");
+    expect(errorPayload.message).toContain("--permission must be one of: view, review");
+
+    const payload = JSON.parse(logs[0] ?? "{}") as { command: string; status: string };
+    expect(payload.command).toBe("invite create");
+    expect(payload.status).toBe("ok");
+  });
+
+  test("conversation session and turn commands map to canonical endpoints", async () => {
+    const requests: RecordedRequest[] = [];
+    const logs: string[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-shared-003";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ path: url.pathname, method, query: url.searchParams, headers, body });
+
+      if (url.pathname === "/v2/conversations/sessions" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-conv-create-001",
+            session: {
+              id: "session-001",
+              channel: "cli",
+              status: "active",
+              topic: "phase2",
+              metadata: {},
+              createdAt: "2026-03-01T11:00:00Z",
+              updatedAt: "2026-03-01T11:00:00Z",
+              lastTurnAt: null,
+            },
+          },
+          201,
+        );
+      }
+
+      if (url.pathname === "/v2/conversations/sessions/session-001" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-conv-get-001",
+          session: {
+            id: "session-001",
+            channel: "cli",
+            status: "active",
+            topic: "phase2",
+            metadata: {},
+            createdAt: "2026-03-01T11:00:00Z",
+            updatedAt: "2026-03-01T11:01:00Z",
+            lastTurnAt: "2026-03-01T11:01:00Z",
+          },
+        });
+      }
+
+      if (url.pathname === "/v2/conversations/sessions/session-001/turns" && method === "POST") {
+        return jsonResponse(
+          {
+            requestId: "req-conv-turn-001",
+            sessionId: "session-001",
+            turn: {
+              id: "turn-001",
+              sessionId: "session-001",
+              role: "user",
+              message: "hello",
+              suggestions: [],
+              metadata: {},
+              createdAt: "2026-03-01T11:01:00Z",
+            },
+          },
+          201,
+        );
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "conversation",
+          "session",
+          "create",
+          "--channel",
+          "cli",
+          "--topic",
+          "phase2",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        ["bun", "src/cli.ts", "conversation", "session", "get", "--session-id", "session-001"],
+        fetchMock,
+      ),
+    ).toBe(0);
+    expect(
+      await run(
+        [
+          "bun",
+          "src/cli.ts",
+          "conversation",
+          "turn",
+          "create",
+          "--session-id",
+          "session-001",
+          "--role",
+          "user",
+          "--message",
+          "hello",
+        ],
+        fetchMock,
+      ),
+    ).toBe(0);
+
+    expect(requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "POST /v2/conversations/sessions",
+      "GET /v2/conversations/sessions/session-001",
+      "POST /v2/conversations/sessions/session-001/turns",
+    ]);
+    const payload = JSON.parse(logs[2] ?? "{}") as { command: string; sessionId: string };
+    expect(payload.command).toBe("conversation turn create");
+    expect(payload.sessionId).toBe("session-001");
+  });
+});


### PR DESCRIPTION
## Summary
- add SHARED lane command groups in `trading-cli`:
  - `shared-validation` (`shared-with-me`, `run`, `artifact`, `review-comment`, `review-decision`)
  - `invite` (`create`, `list`, `accept`, `revoke`)
  - `conversation`/`conversations` (`session create|get`, `turn create`)
- map commands to canonical generated SDK operations (`SharedValidationApi`, `ValidationApi`, `ConversationsApi`)
- enforce canonical permission semantics (`view|review`) and deterministic `--output json|table`
- add smoke coverage for shared-validation/invite/conversation mappings

## Validation
- `bun install --frozen-lockfile` ✅
- `bun run build` ✅
- `bun test` ✅
- `npm pack --dry-run` ✅
- `bun run sdk:drift` ✅
- `bun run sdk:drift --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml` ✅

## Links
- Closes #20
- Refs #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI surface area that issues authenticated requests (including idempotent POSTs) to multiple Platform API endpoints; risk is mainly in argument parsing/validation and request mapping correctness.
> 
> **Overview**
> Adds a new **shared lane** to `trading-cli`, routing `shared-validation`, `invite`, and `conversation`/`conversations` commands through a new `runSharedCommand` entrypoint and updating the top-level help/unknown-command messaging.
> 
> Introduces full CLI implementations for shared validation workflows (list runs shared with you, fetch run/artifact, submit review comments/decisions), invite lifecycle (create/list/accept/revoke with `view|review` permission validation), and conversation sessions/turns (create/get session, create turn), supporting `--output json|table` plus request-id/idempotency handling.
> 
> Adds smoke tests that mock `fetch` to verify each command maps to the expected `v2` endpoints, query params, headers (including `Idempotency-Key`), and emitted JSON payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9281892a04474c5801ee18a81ef43152066766a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds CLI parity for shared validation workflows, invite lifecycle management, and conversation tracking by introducing three new command groups (`shared-validation`, `invite`, `conversation`/`conversations`) that route through a new `runSharedCommand` entrypoint.

**Key Changes:**
- **Command Routing**: Updated `src/cli.ts` to recognize and route the new command groups
- **Implementation**: Added comprehensive `src/shared-command.ts` (1091 lines) implementing all subcommands with proper argument parsing, enum validation, idempotency handling for POST operations, and dual output modes (json|table)
- **API Integration**: Correctly maps to generated SDK operations (`SharedValidationApi`, `ValidationApi`, `ConversationsApi`) with proper authentication headers and request IDs
- **Testing**: Comprehensive smoke tests validate endpoint mapping, query parameters, idempotency keys, and response handling

**Findings:**
- Minor style improvement suggested for `conversation turn` help handling to match the pattern used in `conversation session`
- All commands properly validate inputs (permissions, statuses, decisions, channels, roles) against enum sets
- Idempotency keys are correctly generated for all mutating operations (create/accept/revoke)
- Code follows established patterns from existing command groups (`core-command.ts`, `review-run-command.ts`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured implementation following established codebase patterns with comprehensive test coverage and proper validation; minor style suggestion for help text consistency doesn't impact functionality or safety
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cli.ts | Adds routing for new shared commands (shared-validation, invite, conversation) with updated help text |
| src/shared-command.ts | New file implementing shared-validation, invite, and conversation command groups with proper validation and output formatting; minor help handling inconsistency in conversation turn |
| tests/smoke/shared-cli.test.ts | Comprehensive smoke tests covering all new command groups with mocked fetch calls and validation of request mapping |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs CLI command] --> B{Command type?}
    B -->|shared-validation| C[runSharedCommand]
    B -->|invite| C
    B -->|conversation/conversations| C
    B -->|other| D[Other command handlers]
    
    C --> E{Subcommand?}
    E -->|shared-validation| F[runSharedValidationCommand]
    E -->|invite| G[runInviteCommand]
    E -->|conversation| H[runConversationCommand]
    
    F --> F1{Action?}
    F1 -->|shared-with-me| F2[SharedValidationApi.listValidationRunsSharedWithMeV2]
    F1 -->|run| F3[ValidationApi.getValidationRunV2]
    F1 -->|artifact| F4[ValidationApi.getValidationRunArtifactV2]
    F1 -->|review-comment| F5[SharedValidationApi.createSharedValidationReviewCommentV2]
    F1 -->|review-decision| F6[SharedValidationApi.createSharedValidationReviewDecisionV2]
    
    G --> G1{Action?}
    G1 -->|create| G2[ValidationApi.createValidationRunInviteV2]
    G1 -->|list| G3[ValidationApi.listValidationRunInvitesV2]
    G1 -->|accept| G4[ValidationApi.acceptValidationInviteOnLoginV2]
    G1 -->|revoke| G5[ValidationApi.revokeValidationInviteV2]
    
    H --> H1{Subcommand?}
    H1 -->|session create| H2[ConversationsApi.createConversationSessionV2]
    H1 -->|session get| H3[ConversationsApi.getConversationSessionV2]
    H1 -->|turn create| H4[ConversationsApi.createConversationTurnV2]
    
    F2 --> I[Format & emit output]
    F3 --> I
    F4 --> I
    F5 --> I
    F6 --> I
    G2 --> I
    G3 --> I
    G4 --> I
    G5 --> I
    H2 --> I
    H3 --> I
    H4 --> I
```

<sub>Last reviewed commit: e928189</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->