### PR TITLE
fix(shared): resolve remaining PR #26 conversation help thread

### DIFF
--- a/src/shared-command.ts
+++ b/src/shared-command.ts
@@ -1053,6 +1053,10 @@ async function runConversationCommand(args: string[], context: CommandContext): 
 
   if (subcommand === "turn") {
     const action = args[1];
+    if (!action || action === "--help" || action === "-h") {
+      emitConversationHelp(context);
+      return;
+    }
     if (action !== "create") {
       throw new Error("conversation turn supports only 'create'.");
     }

--- a/tests/smoke/shared-cli.test.ts
+++ b/tests/smoke/shared-cli.test.ts
@@ -602,4 +602,21 @@ describe("shared validation/invite/conversation command groups", () => {
     expect(payload.command).toBe("conversation turn create");
     expect(payload.sessionId).toBe("session-001");
   });
+
+  test("conversation turn help emits usage instead of an error", async () => {
+    const logs: string[] = [];
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    expect(await run(["bun", "src/cli.ts", "conversation", "turn"])).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "conversation", "turn", "--help"])).toBe(0);
+
+    const payload = JSON.parse(logs.at(-1) ?? "{}") as { command: string; usage: string[] };
+    expect(payload.command).toBe("conversation");
+    expect(payload.usage).toContain(
+      "trading-cli conversation turn create --session-id <id> --role user|assistant|system --message <text> [--metadata-json '{...}'] [--output json|table]",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- fix conversation turn help handling (`conversation turn` and `conversation turn --help` now emit usage)
- add regression coverage in `tests/smoke/shared-cli.test.ts`
- resolve/disposition unresolved PR #26 review threads:
  - discussion_r2869610621 resolved with code + test
  - discussion_r2869610623 dispositioned with rationale tied to #27 contract-reconciliation path B

## Validation
- `bun install --frozen-lockfile`
- `bun run build`
- `bun test`
- `npm pack --dry-run`
- `bun run sdk:drift`
- `bun run sdk:drift --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml`

Closes #28

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI argument handling for `conversation turn` and adds a smoke test; no API contract or data handling changes.
> 
> **Overview**
> Fixes the `conversation turn` CLI subcommand to treat missing action or `--help`/`-h` as a help request, emitting `emitConversationHelp` output rather than throwing.
> 
> Adds a smoke test ensuring both `conversation turn` and `conversation turn --help` exit successfully and include the expected usage line in the emitted payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4911fbeebd1c8ee8fc6f77b5dfc4e0eadb4eca98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `conversation turn` and `conversation turn --help` to emit usage information instead of throwing an error when no action is provided. The fix follows the same pattern already used by the `conversation session` subcommand.

## Key Changes
- Added help flag check (`!action || action === "--help" || action === "-h"`) before validation in `runConversationCommand` for the "turn" subcommand
- Added regression test to verify both `conversation turn` and `conversation turn --help` return exit code 0 and emit proper usage information

## Assessment
The implementation is consistent with existing patterns in the codebase, properly tested, and resolves the issue identified in PR #26 review threads. No logical issues or security concerns found.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple bug fix with only 4 lines of code added, follows established patterns, includes comprehensive test coverage, and has no logical or security issues
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/shared-command.ts | Added help flag handling for `conversation turn` subcommand, following the same pattern as `conversation session` |
| tests/smoke/shared-cli.test.ts | Added regression test to verify `conversation turn` and `conversation turn --help` emit usage instead of throwing an error |

</details>


</details>


<sub>Last reviewed commit: 4911fbe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->