### PR TITLE
fix(sdk): make authoritative spec resolution deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Validate publish readiness
-        run: bash scripts/prepare-publish-release.sh --spec "${GITHUB_WORKSPACE}/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml"
+        run: bash scripts/prepare-publish-release.sh --spec "${GITHUB_WORKSPACE}/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml" --revision origin/main
 
   sdk-drift:
     runs-on: ubuntu-latest
@@ -112,4 +112,4 @@ jobs:
           java-version: "21"
 
       - name: Verify SDK drift against authoritative contract
-        run: bash scripts/verify-sdk-drift.sh --spec "${GITHUB_WORKSPACE}/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml"
+        run: bash scripts/verify-sdk-drift.sh --spec "${GITHUB_WORKSPACE}/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml" --revision origin/main

--- a/README.md
+++ b/README.md
@@ -37,13 +37,24 @@ bun run sdk:generate
 bun run sdk:drift
 ```
 
-Authoritative contract source used by default:
+Authoritative spec resolution rule (used by both local scripts and CI):
+- Resolve contract content from git object `<spec-repo>@origin/main:<spec-relative-path>`.
+- `--spec <path>` is used only to identify repository + relative path.
+- Working-tree edits at that path are ignored for generation/drift checks.
+
+Default spec path anchor:
 `/Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml`
 
-Override source explicitly when needed (for CI or alternate local checkout):
+Override path anchor explicitly when needed (same revision rule still applies):
 
 ```bash
 bun run sdk:drift --spec /absolute/path/to/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml
+```
+
+Override revision explicitly when needed:
+
+```bash
+bun run sdk:drift --spec /absolute/path/to/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml --revision origin/main
 ```
 
 Note: SDK sync updates generated API/model files from the authoritative contract source, removes stale generated files, and preserves local barrel exports (`index.ts`, `apis/index.ts`, `models/index.ts`) used by current CLI integration.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -22,10 +22,15 @@
 1. Version is semver-compatible.
 2. `CHANGELOG.md` has an entry for the current package version.
 3. Tag/version alignment (`v<package-version>`) on tag-triggered runs.
-4. SDK drift gate against authoritative `trade-nexus` OpenAPI contract source.
+4. SDK drift gate against authoritative `trade-nexus` OpenAPI contract source, resolved as git object `<spec-repo>@origin/main:<spec-relative-path>`.
 5. `npm pack --dry-run` publish packaging validation.
 
-Authoritative contract path for local validation:
+Authoritative spec rule for local and CI:
+- `--spec` points to a spec path only to identify repository + relative path.
+- Script resolution uses git content at revision `origin/main` by default (or explicit `--revision` / `PLATFORM_API_SPEC_REVISION` override).
+- Working-tree edits at the `--spec` path do not affect drift/generation checks.
+
+Default local path anchor:
 `/Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml`
 
 ## npm publish secrets (names only)

--- a/scripts/generate-sdk.sh
+++ b/scripts/generate-sdk.sh
@@ -8,9 +8,11 @@ CONFIG_PATH="${SCRIPT_DIR}/openapi-generator-sdk.yaml"
 SDK_OUT_DIR="${REPO_ROOT}/src/generated/trade-nexus-sdk"
 GENERATOR_WRAPPER_VERSION="2.21.5"
 DEFAULT_AUTHORITATIVE_SPEC_PATH="/Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml"
+DEFAULT_SPEC_REVISION="${PLATFORM_API_SPEC_REVISION:-origin/main}"
 OPENJDK_HOME="${OPENJDK_HOME:-/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home}"
 
 SPEC_INPUT_PATH="${PLATFORM_API_SPEC_PATH:-${DEFAULT_AUTHORITATIVE_SPEC_PATH}}"
+SPEC_REVISION="${DEFAULT_SPEC_REVISION}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -22,14 +24,29 @@ while [[ $# -gt 0 ]]; do
       SPEC_INPUT_PATH="$2"
       shift 2
       ;;
+    --revision)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --revision" >&2
+        exit 1
+      fi
+      SPEC_REVISION="$2"
+      shift 2
+      ;;
     -h|--help)
       cat <<'USAGE'
-Usage: bash scripts/generate-sdk.sh [--spec <path>]
+Usage: bash scripts/generate-sdk.sh [--spec <path>] [--revision <git-ref>]
 
 Options:
-  --spec <path>  OpenAPI contract file to use for SDK generation.
-                 Defaults to the authoritative local contract path:
-                 /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml
+  --spec <path>      OpenAPI contract file path used to derive repository + relative path.
+                     Working-tree file content is ignored.
+                     Defaults to:
+                     /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml
+  --revision <ref>   Git revision used for authoritative spec content.
+                     Defaults to origin/main (or PLATFORM_API_SPEC_REVISION env var).
+
+Resolution rule:
+  Resolve authoritative spec content from git object <spec-repo>@<git-ref>:<relative-path>.
+  The CLI always generates against that resolved content.
 USAGE
       exit 0
       ;;
@@ -45,12 +62,6 @@ if [[ ! -f "${CONFIG_PATH}" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${SPEC_INPUT_PATH}" ]]; then
-  echo "Authoritative OpenAPI spec not found at: ${SPEC_INPUT_PATH}" >&2
-  echo "Pass --spec <path> to point at a checked-out trade-nexus contract file." >&2
-  exit 1
-fi
-
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/trading-cli-sdk.XXXXXX")"
 SPEC_PATH="${TMP_ROOT}/platform-api.openapi.yaml"
 GEN_OUTPUT_DIR="${TMP_ROOT}/sdk"
@@ -60,7 +71,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-cp "${SPEC_INPUT_PATH}" "${SPEC_PATH}"
+"${SCRIPT_DIR}/resolve-authoritative-spec.sh" \
+  --spec "${SPEC_INPUT_PATH}" \
+  --revision "${SPEC_REVISION}" \
+  --out "${SPEC_PATH}" >/dev/null
 
 if ! java -version >/dev/null 2>&1 && [[ -x "${OPENJDK_HOME}/bin/java" ]]; then
   export JAVA_HOME="${OPENJDK_HOME}"
@@ -89,4 +103,4 @@ node "${SCRIPT_DIR}/extract-openapi-operation-ids.mjs" \
   --spec "${SPEC_PATH}" \
   --out "${SDK_OUT_DIR}/operation-ids.json"
 
-echo "Generated vendored SDK at ${SDK_OUT_DIR} using spec ${SPEC_INPUT_PATH}"
+echo "Generated vendored SDK at ${SDK_OUT_DIR} using ${SPEC_INPUT_PATH}@${SPEC_REVISION}"

--- a/scripts/prepare-publish-release.sh
+++ b/scripts/prepare-publish-release.sh
@@ -19,12 +19,22 @@ while [[ $# -gt 0 ]]; do
       DRIFT_ARGS+=("--spec" "$2")
       shift 2
       ;;
+    --revision)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --revision" >&2
+        exit 1
+      fi
+      DRIFT_ARGS+=("--revision" "$2")
+      shift 2
+      ;;
     -h|--help)
       cat <<'USAGE'
-Usage: bash scripts/prepare-publish-release.sh [--spec <path>]
+Usage: bash scripts/prepare-publish-release.sh [--spec <path>] [--revision <git-ref>]
 
 Options:
-  --spec <path>  Authoritative OpenAPI contract path for SDK drift validation.
+  --spec <path>      Authoritative OpenAPI contract path used to derive repository + relative path.
+  --revision <ref>   Git revision used for authoritative spec content.
+                     Defaults to origin/main (or PLATFORM_API_SPEC_REVISION env var).
 USAGE
       exit 0
       ;;

--- a/scripts/resolve-authoritative-spec.sh
+++ b/scripts/resolve-authoritative-spec.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_AUTHORITATIVE_SPEC_PATH="/Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml"
+DEFAULT_SPEC_REVISION="${PLATFORM_API_SPEC_REVISION:-origin/main}"
+
+SPEC_INPUT_PATH="${PLATFORM_API_SPEC_PATH:-${DEFAULT_AUTHORITATIVE_SPEC_PATH}}"
+SPEC_REVISION="${DEFAULT_SPEC_REVISION}"
+OUTPUT_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --spec)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --spec" >&2
+        exit 1
+      fi
+      SPEC_INPUT_PATH="$2"
+      shift 2
+      ;;
+    --revision)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --revision" >&2
+        exit 1
+      fi
+      SPEC_REVISION="$2"
+      shift 2
+      ;;
+    --out)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --out" >&2
+        exit 1
+      fi
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: bash scripts/resolve-authoritative-spec.sh [--spec <path>] [--revision <git-ref>] --out <path>
+
+Resolution rule:
+  - Resolve authoritative spec content from git object <spec-repo>@<git-ref>:<relative-path>.
+  - --spec points to a file path only to identify repository + relative path.
+  - Working-tree modifications at --spec are ignored.
+
+Options:
+  --spec <path>      Spec file path used to derive repository and relative path.
+                     Default:
+                     /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml
+  --revision <ref>   Git revision used for authoritative resolution.
+                     Default: origin/main (or PLATFORM_API_SPEC_REVISION env var).
+  --out <path>       Output file path for resolved spec content.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${OUTPUT_PATH}" ]]; then
+  echo "Missing required argument: --out <path>" >&2
+  exit 1
+fi
+
+SPEC_DIR="$(cd "$(dirname "${SPEC_INPUT_PATH}")" && pwd -P)"
+SPEC_FILE_NAME="$(basename "${SPEC_INPUT_PATH}")"
+SPEC_ABS_PATH="${SPEC_DIR}/${SPEC_FILE_NAME}"
+
+if [[ ! -f "${SPEC_ABS_PATH}" ]]; then
+  echo "Spec path does not exist on disk: ${SPEC_ABS_PATH}" >&2
+  exit 1
+fi
+
+if ! SPEC_REPO_ROOT="$(git -C "${SPEC_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "Spec path is not inside a git repository: ${SPEC_ABS_PATH}" >&2
+  exit 1
+fi
+
+if [[ "${SPEC_ABS_PATH}" != "${SPEC_REPO_ROOT}/"* ]]; then
+  echo "Spec path must be inside repository root ${SPEC_REPO_ROOT}: ${SPEC_ABS_PATH}" >&2
+  exit 1
+fi
+
+SPEC_REL_PATH="${SPEC_ABS_PATH#${SPEC_REPO_ROOT}/}"
+
+if ! git -C "${SPEC_REPO_ROOT}" rev-parse --verify --quiet "${SPEC_REVISION}^{commit}" >/dev/null; then
+  echo "Revision '${SPEC_REVISION}' was not found in ${SPEC_REPO_ROOT}." >&2
+  echo "Run: git -C ${SPEC_REPO_ROOT} fetch origin main" >&2
+  exit 1
+fi
+
+if ! git -C "${SPEC_REPO_ROOT}" cat-file -e "${SPEC_REVISION}:${SPEC_REL_PATH}" 2>/dev/null; then
+  echo "Spec blob '${SPEC_REL_PATH}' not found at revision '${SPEC_REVISION}' in ${SPEC_REPO_ROOT}." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+git -C "${SPEC_REPO_ROOT}" show "${SPEC_REVISION}:${SPEC_REL_PATH}" > "${OUTPUT_PATH}"
+
+echo "Resolved authoritative spec from ${SPEC_REPO_ROOT}@${SPEC_REVISION}:${SPEC_REL_PATH}" >&2

--- a/scripts/verify-sdk-drift.sh
+++ b/scripts/verify-sdk-drift.sh
@@ -18,12 +18,22 @@ while [[ $# -gt 0 ]]; do
       GEN_ARGS+=("--spec" "$2")
       shift 2
       ;;
+    --revision)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --revision" >&2
+        exit 1
+      fi
+      GEN_ARGS+=("--revision" "$2")
+      shift 2
+      ;;
     -h|--help)
       cat <<'USAGE'
-Usage: bash scripts/verify-sdk-drift.sh [--spec <path>]
+Usage: bash scripts/verify-sdk-drift.sh [--spec <path>] [--revision <git-ref>]
 
 Options:
-  --spec <path>  OpenAPI contract file to validate drift against.
+  --spec <path>      OpenAPI contract file path used for repository + relative-path resolution.
+  --revision <ref>   Git revision used for authoritative spec content.
+                     Defaults to origin/main (or PLATFORM_API_SPEC_REVISION env var).
 USAGE
       exit 0
       ;;

--- a/tests/contract/spec-source-resolution.test.ts
+++ b/tests/contract/spec-source-resolution.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+function run(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return run("git", args, cwd);
+}
+
+describe("authoritative spec resolution", () => {
+  test("resolves spec content from origin/main revision, not working tree edits", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "trading-cli-spec-resolve-"));
+
+    try {
+      const repoRoot = join(sandbox, "trade-nexus");
+      const specDir = join(repoRoot, "docs/architecture/specs");
+      const specPath = join(specDir, "platform-api.openapi.yaml");
+      const resolvedOutPath = join(sandbox, "resolved.openapi.yaml");
+      const resolverPath = resolve(process.cwd(), "scripts/resolve-authoritative-spec.sh");
+
+      mkdirSync(specDir, { recursive: true });
+      git(sandbox, "init", "trade-nexus");
+      git(repoRoot, "config", "user.email", "spec-test@example.com");
+      git(repoRoot, "config", "user.name", "Spec Test");
+
+      writeFileSync(
+        specPath,
+        "openapi: 3.0.3\npaths:\n  /v2/test:\n    get:\n      operationId: fromOriginMain\n",
+      );
+      git(repoRoot, "add", ".");
+      git(repoRoot, "commit", "-m", "seed authoritative spec");
+      git(repoRoot, "branch", "-M", "main");
+      git(repoRoot, "update-ref", "refs/remotes/origin/main", "HEAD");
+
+      writeFileSync(
+        specPath,
+        "openapi: 3.0.3\npaths:\n  /v2/test:\n    get:\n      operationId: fromWorkingTree\n",
+      );
+
+      run(
+        "bash",
+        [resolverPath, "--spec", specPath, "--revision", "origin/main", "--out", resolvedOutPath],
+        process.cwd(),
+      );
+
+      const resolvedText = readFileSync(resolvedOutPath, "utf8");
+      expect(resolvedText).toContain("operationId: fromOriginMain");
+      expect(resolvedText).not.toContain("operationId: fromWorkingTree");
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- define one authoritative spec resolution rule for local + CI: resolve OpenAPI content from git object `<spec-repo>@origin/main:<spec-relative-path>`
- add shared resolver script `scripts/resolve-authoritative-spec.sh` and route `sdk:generate` through it
- update `sdk:drift` and publish-release scripts to support/pass `--revision` and keep default `origin/main`
- align CI `publish-validation` and `sdk-drift` invocations to pass `--revision origin/main`
- add regression test covering origin/main-vs-working-tree resolution behavior
- document the rule in README and RELEASE_PROCESS docs

## Validation
- bun install --frozen-lockfile
- bun run build
- bun test
- npm pack --dry-run
- bun run sdk:drift
- bun run sdk:drift --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml

Closes #31
Refs #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the SDK generation/drift gates source their OpenAPI spec (now via git object resolution at a revision), which can break CI/release checks if revision/paths or git refs aren’t available in the checked-out spec repo.
> 
> **Overview**
> Makes SDK generation/drift checks deterministic by resolving the OpenAPI spec from a git object (`<spec-repo>@<revision>:<relative-path>`) instead of using working-tree file contents.
> 
> Adds `scripts/resolve-authoritative-spec.sh` and routes `generate-sdk.sh` through it, introducing a `--revision` flag (default `origin/main` / `PLATFORM_API_SPEC_REVISION`) that is plumbed through `verify-sdk-drift.sh` and `prepare-publish-release.sh`, and explicitly passed in CI.
> 
> Updates docs (`README.md`, `RELEASE_PROCESS.md`) to describe the new resolution rule and adds a regression test ensuring working-tree edits don’t affect resolved spec content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1f8970bb5c42681ef70ba34ce1ebb9661e7b51b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces deterministic spec resolution by always reading OpenAPI specs from git objects at a specific revision (default `origin/main`) rather than working tree files.

**Key Changes:**
- Added `scripts/resolve-authoritative-spec.sh` that uses `git show <revision>:<path>` to extract spec content from git history
- Modified SDK generation and drift validation scripts to route through the new resolver with `--revision` parameter support
- Updated CI workflows to explicitly pass `--revision origin/main` for authoritative resolution
- Added regression test validating that working-tree modifications are correctly ignored
- Updated documentation in README and RELEASE_PROCESS to explain the resolution rule

**Implementation Quality:**
- Proper error handling with `set -euo pipefail` and comprehensive validation
- Secure handling of user inputs with proper quoting and path resolution
- Clear separation of concerns: `--spec` identifies repo/path, `--revision` controls content source
- Good test coverage of the core resolution behavior
- Clear error messages guide users when revision or spec path is not found

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- Score reflects well-designed implementation with proper error handling, security considerations, comprehensive test coverage, and clear documentation. The approach elegantly solves the deterministic spec resolution problem using git primitives.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/resolve-authoritative-spec.sh | New script that resolves spec content from git objects at specified revision (default origin/main), properly handles path resolution, includes comprehensive error handling and validation |
| scripts/generate-sdk.sh | Updated to use resolve-authoritative-spec.sh, added --revision parameter support, removed direct file copy in favor of git-based resolution |
| tests/contract/spec-source-resolution.test.ts | New regression test validating that resolver uses origin/main content and correctly ignores working tree modifications |
| .github/workflows/ci.yml | Added --revision origin/main to publish-validation and sdk-drift jobs to enforce authoritative spec resolution in CI |
| scripts/verify-sdk-drift.sh | Added --revision parameter support and passes it through to generate-sdk.sh for consistent spec resolution |
| scripts/prepare-publish-release.sh | Added --revision parameter support and passes it through to verify-sdk-drift.sh for publish validation |
| README.md | Updated documentation to explain authoritative spec resolution rule, clarified that --spec identifies repo/path while working-tree edits are ignored |
| RELEASE_PROCESS.md | Updated release documentation to explain git-based spec resolution rule and revision override options |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User/CI runs script] --> B{Which script?}
    B -->|sdk:generate| C[generate-sdk.sh]
    B -->|sdk:drift| D[verify-sdk-drift.sh]
    B -->|publish validation| E[prepare-publish-release.sh]
    
    C --> F[resolve-authoritative-spec.sh]
    D --> C
    E --> D
    
    F --> G[Resolve spec path to<br/>absolute path]
    G --> H[Find git repository root]
    H --> I{Revision exists?}
    I -->|No| J[Error: revision not found<br/>Suggest: git fetch]
    I -->|Yes| K{Spec blob exists<br/>at revision?}
    K -->|No| L[Error: spec not found<br/>at revision]
    K -->|Yes| M[git show revision:path]
    M --> N[Write to temp file]
    N --> O[SDK generation uses<br/>resolved spec content]
    
    style F fill:#90EE90
    style M fill:#FFD700
    style J fill:#FFB6C1
    style L fill:#FFB6C1
```

<sub>Last reviewed commit: d1f8970</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->