### PR TITLE
feat(release): migrate to npm Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,8 +31,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -44,12 +48,11 @@ jobs:
       - name: Validate semver/changelog/tag, SDK drift, and package dry-run
         run: bash scripts/prepare-publish-release.sh --spec "${GITHUB_WORKSPACE}/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml"
 
-      - name: Publish package to npm
+      - name: Publish package to npm (Trusted Publishing via OIDC)
         if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish == 'true' }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_UPDATE_NOTIFIER: "false"
-        run: npm publish --access public
+        run: npm publish --access public --provenance
 
       - name: Dry-run complete
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish != 'true' }}


### PR DESCRIPTION
## Summary
- Migrates `release.yml` from token-based (`NPM_TOKEN` secret) to OIDC-based Trusted Publishing
- Adds `id-token: write` permission for GitHub Actions OIDC token generation
- Upgrades Node to 22 and installs latest npm (≥11.5.1 required for trusted publishing)
- Replaces `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` with `--provenance` flag

## Context
- Trusted Publisher connection configured on npmjs.com: `iamtxena/trading-cli` → `release.yml`
- Bootstrap publish of `trading-cli@0.1.0` completed with token-based auth
- After this PR merges, the `NPM_TOKEN` secret and `trading-cli-bootstrap` npm token can be deleted

## Test plan
- [ ] Merge PR
- [ ] Bump version to 0.1.1, tag `v0.1.1`, push tag
- [ ] Verify release workflow publishes successfully via OIDC (no token)
- [ ] Delete `NPM_TOKEN` GitHub secret
- [ ] Delete `trading-cli-bootstrap` npm token

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline’s authentication mechanism and runtime (Node/npm), which can break publishing if OIDC/npm configuration is incorrect, but impact is limited to CI release publishing.
> 
> **Overview**
> Switches the `release.yml` workflow from token-based npm auth to **npm Trusted Publishing via GitHub OIDC** by granting `id-token: write`, dropping `NODE_AUTH_TOKEN`, and publishing with `npm publish --provenance`.
> 
> Updates the release runtime by bumping Node from `20` to `22` and adding a step to install the latest npm to ensure Trusted Publishing support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a0e6b19852df1df99600a7457afddc6846f0703. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully migrates the npm publishing workflow from token-based authentication to **OIDC-based Trusted Publishing**, eliminating the need for the `NPM_TOKEN` secret.

**Key changes:**
- Added `id-token: write` permission to enable GitHub OIDC token generation for npm authentication
- Upgraded Node from 20 to 22 and added step to install latest npm (≥11.5.1 required for Trusted Publishing)
- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` environment variable from publish step
- Added `--provenance` flag to `npm publish` command to enable package attestation

**Context:**
- Trusted Publisher configuration is already set up on npmjs.com linking `iamtxena/trading-cli` → `release.yml`
- Bootstrap publish of `trading-cli@0.1.0` was completed with token-based auth
- After merge, the `NPM_TOKEN` GitHub secret and `trading-cli-bootstrap` npm token can be safely deleted

**Note:** The CI workflow (ci.yml) still uses Node 20 while the release workflow now uses Node 22. This inconsistency is minor since the project primarily uses Bun for building and testing, but consider aligning Node versions across workflows for consistency.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it correctly implements npm Trusted Publishing following best practices
- Score reflects well-executed OIDC migration with proper permissions and configuration. Deducted one point due to: (1) dependency on external npmjs.com Trusted Publisher configuration which could cause failures if misconfigured, (2) minor Node version inconsistency between CI (Node 20) and release (Node 22) workflows, and (3) unpinned npm@latest which could introduce future unpredictability. However, these are low-risk concerns and the PR description confirms the external configuration is already complete.
- No files require special attention - the release.yml changes are straightforward and correctly implement the OIDC migration

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Migrated from token-based npm auth to OIDC Trusted Publishing by adding `id-token: write` permission, upgrading Node to 22, installing latest npm, and replacing `NODE_AUTH_TOKEN` with `--provenance` flag |

</details>


</details>


<sub>Last reviewed commit: 6a0e6b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->