### PR TITLE
docs: complete CLI guide and workflow playbooks

### DIFF
--- a/COMMAND_REFERENCE.md
+++ b/COMMAND_REFERENCE.md
@@ -1,54 +1,307 @@
 # Command Reference
 
-## Validation Run Commands
+Complete end-user guide for `trading-cli`.
 
-1. `trading-cli review-run trigger`
-   - Starts a validation review run through `POST /v2/validation-runs` using the generated SDK.
-   - Returns stable identifiers and review-web URLs:
-     - `runId`
-     - `reviewWeb.path`
-     - `reviewWeb.url`
-   - Optional render trigger: `--render html,pdf`.
+## Quick Start
 
-2. `trading-cli review-run retrieve`
-   - Retrieves review run data from the review API lane via generated SDK.
-   - Modes:
-     - `--run-id <id>`: run summary + optional render status.
-     - no `--run-id`: list review runs with filters.
+```bash
+bun install
+bun run build
+```
 
-3. `trading-cli review-run render`
-   - Triggers optional HTML/PDF derived output from canonical validation JSON.
-   - Route: `POST /v2/validation-runs/{runId}/render`.
+Set runtime environment (required for non-registration commands):
 
-4. `trading-cli validation run <trigger|retrieve|render>`
-   - Alias surface for the same review-run workflow.
-   - Kept for compatibility with validation-oriented command naming.
+```bash
+export PLATFORM_API_BASE_URL="https://api-nexus.lona.agency"
+export PLATFORM_API_BEARER_TOKEN="<token>"
+# Optional fallback auth:
+# export PLATFORM_API_KEY="<api-key>"
+```
 
-## Bot Registration + Key Lifecycle
+Notes:
+- `PLATFORM_API_BASE_URL` must point to `api-nexus.lona.agency` (or local loopback hosts like `http://localhost:3000`).
+- Provider hosts are blocked by CLI boundary checks.
+- `register invite` and `register partner` can run without an auth token.
 
-1. `trading-cli register invite`
-   - Self-registers bot through invite-code trial flow.
-   - Route: `POST /v2/validation-bots/registrations/invite-code`.
-   - Required flags (unless `--input` is used): `--invite-code`, `--bot-name`.
+## Global Conventions
 
-2. `trading-cli register partner`
-   - Self-registers bot through partner key/secret bootstrap flow.
-   - Route: `POST /v2/validation-bots/registrations/partner-bootstrap`.
-   - Required flags (unless `--input` is used): `--partner-key`, `--partner-secret`, `--owner-email`, `--bot-name`.
+- `--request-id <id>`: optional on most commands. If omitted, CLI generates one.
+- `--idempotency-key <key>`: optional on mutation commands that support dedupe. If omitted, CLI generates one.
+- `--output json|table`: supported by core, dataset, shared-validation, invite, and conversation commands. Default is `json`.
+- `--input <file.json>`: where supported, provides full request payload from JSON file.
+- CSV flags accept comma-separated values without spaces (example: `ema,zigzag,rsi`).
 
-3. `trading-cli key rotate`
-   - Rotates bot API key and returns raw key once.
-   - Route: `POST /v2/validation-bots/{botId}/keys/rotate`.
+## Command Groups
 
-4. `trading-cli key revoke`
-   - Revokes bot API key metadata (raw key is never returned).
-   - Route: `POST /v2/validation-bots/{botId}/keys/{keyId}/revoke`.
+### research
 
-5. `trading-cli bot <register|key> ...`
-   - Alias surface for `register` and `key` commands.
+#### `research scan`
+Discover regimes and strategy ideas.
 
-## Examples
+Usage:
+```bash
+trading-cli research scan --asset-classes <csv> --capital <number> [--constraints-json <json>] [--version v1|v2] [--request-id <id>] [--output json|table]
+trading-cli research scan --input <market-scan.json> [--version v1|v2] [--request-id <id>] [--output json|table]
+```
 
+Options:
+- `--input <file>`: full `MarketScanRequest` payload.
+- `--asset-classes <csv>`: required when `--input` is not used.
+- `--capital <number>`: required when `--input` is not used.
+- `--constraints-json <json-object>`: optional constraints object.
+- `--version <v1|v2>`: defaults to `v2`.
+
+Example:
+```bash
+trading-cli research scan \
+  --asset-classes crypto,stocks \
+  --capital 50000 \
+  --constraints-json '{"maxDrawdownPct":8}' \
+  --version v2 \
+  --output table
+```
+
+### strategy
+
+#### `strategy create`
+```bash
+trading-cli strategy create --description "Momentum breakout" [--name <name>] [--provider <provider>] [--request-id <id>] [--output json|table]
+trading-cli strategy create --input <create-strategy.json> [--request-id <id>] [--output json|table]
+```
+
+Required when no `--input`:
+- `--description <text>`
+
+#### `strategy get`
+```bash
+trading-cli strategy get --strategy-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `strategy list`
+```bash
+trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--request-id <id>] [--output json|table]
+```
+
+#### `strategy update`
+```bash
+trading-cli strategy update --strategy-id <id> [--name <name>] [--description <text>] [--status draft|testing|tested|deployable|archived|failed] [--tags <csv>] [--request-id <id>] [--output json|table]
+trading-cli strategy update --strategy-id <id> --input <update-strategy.json> [--request-id <id>] [--output json|table]
+```
+
+At least one of `--name`, `--description`, `--status`, `--tags`, or `--input` is required.
+
+Example:
+```bash
+trading-cli strategy create \
+  --name "BTC Breakout v1" \
+  --description "1h breakout with volatility filter" \
+  --provider lona
+```
+
+### backtest
+
+#### `backtest create`
+```bash
+trading-cli backtest create --strategy-id <id> --start-date <iso-date> --end-date <iso-date> [--dataset-ids <csv>] [--data-ids <csv>] [--initial-cash <number>] [--request-id <id>] [--output json|table]
+trading-cli backtest create --strategy-id <id> --input <create-backtest.json> [--request-id <id>] [--output json|table]
+```
+
+#### `backtest get`
+```bash
+trading-cli backtest get --backtest-id <id> [--request-id <id>] [--output json|table]
+```
+
+Example:
+```bash
+trading-cli backtest create \
+  --strategy-id strat-001 \
+  --start-date 2025-01-01 \
+  --end-date 2025-03-01 \
+  --dataset-ids dataset-btc-1h-2025 \
+  --initial-cash 10000
+```
+
+### deploy
+
+#### `deploy create`
+```bash
+trading-cli deploy create --strategy-id <id> --mode paper|live --capital <number> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+trading-cli deploy create --input <create-deployment.json> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+#### `deploy get`
+```bash
+trading-cli deploy get --deployment-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `deploy list`
+```bash
+trading-cli deploy list [--status queued|running|paused|stopping|stopped|failed] [--cursor <token>] [--request-id <id>] [--output json|table]
+```
+
+#### `deploy stop`
+```bash
+trading-cli deploy stop --deployment-id <id> [--reason <text>] [--request-id <id>] [--output json|table]
+```
+
+Example:
+```bash
+trading-cli deploy create \
+  --strategy-id strat-001 \
+  --mode paper \
+  --capital 15000 \
+  --idempotency-key idem-core-deploy-001
+```
+
+### portfolio
+
+#### `portfolio list`
+```bash
+trading-cli portfolio list [--request-id <id>] [--output json|table]
+```
+
+#### `portfolio get`
+```bash
+trading-cli portfolio get --portfolio-id <id> [--request-id <id>] [--output json|table]
+```
+
+### order
+
+#### `order create`
+`order create` currently requires `--input`.
+
+```bash
+trading-cli order create --input <create-order.json> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+#### `order get`
+```bash
+trading-cli order get --order-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `order list`
+```bash
+trading-cli order list [--status pending|filled|cancelled|failed] [--cursor <token>] [--request-id <id>] [--output json|table]
+```
+
+#### `order cancel`
+```bash
+trading-cli order cancel --order-id <id> [--request-id <id>] [--output json|table]
+```
+
+Example (`order create` payload):
+```bash
+cat > /tmp/create-order.json <<'JSON'
+{
+  "symbol": "BTCUSDT",
+  "side": "buy",
+  "type": "market",
+  "quantity": 0.1
+}
+JSON
+
+trading-cli order create --input /tmp/create-order.json
+```
+
+### dataset
+
+Lifecycle group for upload, validation, transform, publish, and status.
+
+#### `dataset upload init`
+```bash
+trading-cli dataset upload init --filename <file> --content-type <mime> --size-bytes <bytes> [--request-id <id>] [--output json|table]
+trading-cli dataset upload init --input <init-upload.json> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset upload complete`
+```bash
+trading-cli dataset upload complete --dataset-id <id> [--upload-token <token>] [--request-id <id>] [--output json|table]
+trading-cli dataset upload complete --dataset-id <id> --input <complete-upload.json> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset validate`
+```bash
+trading-cli dataset validate --dataset-id <id> [--column-mapping-json '{"timestamp":"ts"}'] [--request-id <id>] [--output json|table]
+trading-cli dataset validate --dataset-id <id> --input <validate.json> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset transform`
+```bash
+trading-cli dataset transform --dataset-id <id> --frequency <value> [--request-id <id>] [--output json|table]
+trading-cli dataset transform --dataset-id <id> --input <transform.json> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset publish`
+```bash
+trading-cli dataset publish --dataset-id <id> [--mode explicit|just_in_time] [--request-id <id>] [--output json|table]
+trading-cli dataset publish --dataset-id <id> --input <publish.json> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset get`
+```bash
+trading-cli dataset get --dataset-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset status`
+```bash
+trading-cli dataset status --dataset-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `dataset list`
+```bash
+trading-cli dataset list [--cursor <token>] [--request-id <id>] [--output json|table]
+```
+
+Aliases:
+- `trading-cli dataset init ...` is alias for `dataset upload init`.
+- `trading-cli dataset complete ...` is alias for `dataset upload complete`.
+
+Example:
+```bash
+trading-cli dataset upload init \
+  --filename btc-1h.csv \
+  --content-type text/csv \
+  --size-bytes 1024
+
+trading-cli dataset upload complete --dataset-id dataset-001 --upload-token upload-token-001
+trading-cli dataset validate --dataset-id dataset-001 --column-mapping-json '{"timestamp":"ts"}'
+trading-cli dataset transform --dataset-id dataset-001 --frequency 1h
+trading-cli dataset publish --dataset-id dataset-001 --mode explicit
+trading-cli dataset status --dataset-id dataset-001
+```
+
+### validation / review-run
+
+`review-run` is the canonical validation run surface.
+
+Alias:
+- `trading-cli validation run <...>` routes to the same handlers.
+- `review-run get` is alias for `review-run retrieve`.
+
+#### `review-run trigger`
+```bash
+trading-cli review-run trigger --strategy-id <id> --requested-indicators <csv> --dataset-ids <csv> --backtest-report-ref <ref> [--provider-ref-id <id>] [--prompt <text>] [--profile FAST|STANDARD|EXPERT] [--render html,pdf] [--request-id <id>] [--idempotency-key <key>]
+trading-cli review-run trigger --input <create-validation-run.json> [--render html,pdf] [--request-id <id>] [--idempotency-key <key>]
+```
+
+When not using `--input`, required flags are:
+- `--strategy-id`
+- `--requested-indicators`
+- `--dataset-ids`
+- `--backtest-report-ref`
+
+#### `review-run retrieve`
+```bash
+trading-cli review-run retrieve --run-id <id> [--render-format html|pdf] [--raw] [--request-id <id>]
+trading-cli review-run retrieve [--status queued|running|completed|failed] [--final-decision pending|pass|conditional_pass|fail] [--cursor <token>] [--limit 1..100] [--request-id <id>]
+```
+
+#### `review-run render`
+```bash
+trading-cli review-run render --run-id <id> --format html|pdf [--request-id <id>] [--idempotency-key <key>]
+```
+
+Example:
 ```bash
 trading-cli review-run trigger \
   --strategy-id strat-001 \
@@ -58,26 +311,172 @@ trading-cli review-run trigger \
   --render html
 
 trading-cli review-run retrieve --run-id valrun-20260220-0001 --render-format html
-
-trading-cli review-run retrieve --status completed --final-decision conditional_pass --limit 25
-
 trading-cli review-run render --run-id valrun-20260220-0001 --format pdf
+```
 
-trading-cli register invite --invite-code INVITE-123 --bot-name team-d-trial
+### bot / register / key
 
-trading-cli register partner \
-  --partner-key partner-key-001 \
-  --partner-secret partner-secret-001 \
-  --owner-email team-d@example.com \
-  --bot-name team-d-prod
+Bot bootstrap and key lifecycle.
 
+Aliases:
+- `trading-cli bot register ...` maps to `trading-cli register ...`.
+- `trading-cli bot key ...` maps to `trading-cli key ...`.
+- `register invite-code` is accepted as alias of `register invite`.
+
+#### `register invite`
+```bash
+trading-cli register invite --invite-code <code> --bot-name <name> [--metadata-json <json>] [--metadata-file <file>] [--request-id <id>] [--idempotency-key <key>]
+trading-cli register invite --input <register-invite.json> [--request-id <id>] [--idempotency-key <key>]
+```
+
+#### `register partner`
+```bash
+trading-cli register partner --partner-key <key> --partner-secret <secret> --owner-email <email> --bot-name <name> [--metadata-json <json>] [--metadata-file <file>] [--request-id <id>] [--idempotency-key <key>]
+trading-cli register partner --input <register-partner.json> [--request-id <id>] [--idempotency-key <key>]
+```
+
+#### `key rotate`
+```bash
+trading-cli key rotate --bot-id <id> [--reason <text>] [--request-id <id>] [--idempotency-key <key>]
+```
+
+#### `key revoke`
+```bash
+trading-cli key revoke --bot-id <id> --key-id <id> [--reason <text>] [--request-id <id>] [--idempotency-key <key>]
+```
+
+Example:
+```bash
+trading-cli register invite --invite-code INVITE-TEAM-D-001 --bot-name wave-invite-bot
 trading-cli key rotate --bot-id bot-001 --reason "routine rotation"
-
 trading-cli key revoke --bot-id bot-001 --key-id key-001 --reason "compromised"
 ```
 
-## Output Policy
+### shared-validation
 
-- JSON output is canonical for automation and cross-tool integration.
-- Errors are emitted as structured JSON objects with HTTP/request metadata when available.
-- Issued raw API keys are shown once only on registration/rotation responses. Store securely immediately.
+Review surface for runs shared with you.
+
+Aliases:
+- `shared-validation list` -> `shared-validation shared-with-me`
+- `shared-validation comment` -> `shared-validation review-comment`
+- `shared-validation decision` -> `shared-validation review-decision`
+
+#### `shared-validation shared-with-me`
+```bash
+trading-cli shared-validation shared-with-me [--status queued|running|completed|failed] [--final-decision pass|conditional_pass|fail] [--permission view|review] [--cursor <token>] [--limit 1..100] [--request-id <id>] [--output json|table]
+```
+
+#### `shared-validation run`
+```bash
+trading-cli shared-validation run --run-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `shared-validation artifact`
+```bash
+trading-cli shared-validation artifact --run-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `shared-validation review-comment`
+```bash
+trading-cli shared-validation review-comment --run-id <id> --body <text> [--evidence-refs <csv>] [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+trading-cli shared-validation review-comment --run-id <id> --input <review-comment.json> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+#### `shared-validation review-decision`
+```bash
+trading-cli shared-validation review-decision --run-id <id> --action approve|reject --decision pass|conditional_pass|fail --reason <text> [--evidence-refs <csv>] [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+trading-cli shared-validation review-decision --run-id <id> --input <review-decision.json> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+Example:
+```bash
+trading-cli shared-validation shared-with-me --permission review --status completed --output table
+trading-cli shared-validation review-comment --run-id run-001 --body "Looks good"
+trading-cli shared-validation review-decision --run-id run-001 --action approve --decision pass --reason "All checks pass"
+```
+
+### invite
+
+Manage review sharing invites.
+
+#### `invite create`
+```bash
+trading-cli invite create --run-id <id> --email <email> [--permission view|review] [--message <text>] [--expires-at <iso-timestamp>] [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+trading-cli invite create --run-id <id> --input <invite-create.json> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+#### `invite list`
+```bash
+trading-cli invite list --run-id <id> [--cursor <token>] [--limit 1..100] [--request-id <id>] [--output json|table]
+```
+
+#### `invite accept`
+```bash
+trading-cli invite accept --invite-id <id> --accepted-email <email> [--login-session-id <id>] [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+trading-cli invite accept --invite-id <id> --input <invite-accept.json> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+#### `invite revoke`
+```bash
+trading-cli invite revoke --invite-id <id> [--request-id <id>] [--idempotency-key <key>] [--output json|table]
+```
+
+Example:
+```bash
+trading-cli invite create --run-id run-001 --email reviewer@example.com --permission review
+trading-cli invite list --run-id run-001 --limit 20
+trading-cli invite accept --invite-id invite-001 --accepted-email reviewer@example.com
+trading-cli invite revoke --invite-id invite-001
+```
+
+### conversation
+
+Conversation sessions and turns.
+
+Alias:
+- `trading-cli conversations ...` routes to `conversation ...`.
+
+#### `conversation session create`
+```bash
+trading-cli conversation session create --channel cli|web|openclaw [--topic <text>] [--metadata-json '{"key":"value"}'] [--request-id <id>] [--output json|table]
+trading-cli conversation session create --input <session-create.json> [--request-id <id>] [--output json|table]
+```
+
+#### `conversation session get`
+```bash
+trading-cli conversation session get --session-id <id> [--request-id <id>] [--output json|table]
+```
+
+#### `conversation turn create`
+```bash
+trading-cli conversation turn create --session-id <id> --role user|assistant|system --message <text> [--metadata-json '{"key":"value"}'] [--request-id <id>] [--output json|table]
+trading-cli conversation turn create --session-id <id> --input <turn-create.json> [--request-id <id>] [--output json|table]
+```
+
+Example:
+```bash
+trading-cli conversation session create --channel cli --topic "phase2"
+trading-cli conversation session get --session-id session-001
+trading-cli conversation turn create --session-id session-001 --role user --message "hello"
+```
+
+## After CLI-A: knowledge / data-export
+
+The generated SDK already contains `KnowledgeApi` and `DataApi` operations, but this CLI build does not expose command groups for them yet.
+
+Current behavior:
+```bash
+trading-cli knowledge
+trading-cli data-export
+# Both currently fail with: Unknown command ...
+```
+
+Interim guidance:
+- Use `research scan --version v2` for embedded `knowledgeEvidence` in scan output.
+- Use existing `backtest get` / `review-run retrieve --raw` artifacts until `data-export` commands are added.
+
+## Output and Errors
+
+- Success responses are machine-readable JSON (or table text when `--output table` is supported).
+- Failures emit structured JSON error envelopes to stderr.
+- Registration and key rotation responses include raw keys one time only; store immediately.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,106 @@ trading-cli key rotate --help
 trading-cli key revoke --help
 ```
 
+## Workflow playbooks
+
+### 1. Strategy lifecycle (scan -> create -> backtest -> deploy paper/live)
+
+```bash
+# 1) Scan market context and ideas
+trading-cli research scan \
+  --asset-classes crypto,stocks \
+  --capital 50000 \
+  --version v2 \
+  --output table
+
+# 2) Create strategy
+trading-cli strategy create \
+  --name "BTC Breakout v1" \
+  --description "1h breakout with trend confirmation"
+
+# 3) Backtest
+STRATEGY_ID="strat-001" # replace with your strategy id
+trading-cli backtest create \
+  --strategy-id "$STRATEGY_ID" \
+  --start-date 2025-01-01 \
+  --end-date 2025-03-01 \
+  --dataset-ids dataset-btc-1h-2025 \
+  --initial-cash 10000
+
+BACKTEST_ID="backtest-001" # replace with your backtest id
+trading-cli backtest get --backtest-id "$BACKTEST_ID" --output table
+
+# 4) Deploy paper first, then live
+trading-cli deploy create --strategy-id "$STRATEGY_ID" --mode paper --capital 10000
+trading-cli deploy create --strategy-id "$STRATEGY_ID" --mode live --capital 10000
+```
+
+### 2. Validation lifecycle (trigger -> review -> verdict -> render)
+
+```bash
+# 1) Trigger validation run
+trading-cli review-run trigger \
+  --strategy-id strat-001 \
+  --requested-indicators ema,zigzag \
+  --dataset-ids dataset-btc-1h-2025 \
+  --backtest-report-ref blob://validation/candidate/backtest.json
+
+RUN_ID="valrun-20260220-0001" # replace with returned run id
+
+# 2) Review summary + raw artifact state
+trading-cli review-run retrieve --run-id "$RUN_ID" --raw
+
+# 3) Record review verdict (for reviewers with shared review permission)
+trading-cli shared-validation review-comment \
+  --run-id "$RUN_ID" \
+  --body "Risk checks complete. Ready for verdict."
+
+trading-cli shared-validation review-decision \
+  --run-id "$RUN_ID" \
+  --action approve \
+  --decision conditional_pass \
+  --reason "Meets guardrails with minor follow-up."
+
+# 4) Render final review artifact and check status
+trading-cli review-run render --run-id "$RUN_ID" --format pdf
+trading-cli review-run retrieve --run-id "$RUN_ID" --render-format pdf
+```
+
+### 3. Shared review lifecycle (invite -> shared-with-me -> comment/decision)
+
+```bash
+# Owner invites reviewer
+RUN_ID="run-001"
+trading-cli invite create \
+  --run-id "$RUN_ID" \
+  --email reviewer@example.com \
+  --permission review \
+  --message "Please review today."
+
+# Reviewer accepts invite
+INVITE_ID="invite-001"
+trading-cli invite accept \
+  --invite-id "$INVITE_ID" \
+  --accepted-email reviewer@example.com
+
+# Reviewer lists runs shared with them
+trading-cli shared-validation shared-with-me \
+  --permission review \
+  --status completed \
+  --output table
+
+# Reviewer leaves comment and decision
+trading-cli shared-validation review-comment \
+  --run-id "$RUN_ID" \
+  --body "LGTM after evidence review."
+
+trading-cli shared-validation review-decision \
+  --run-id "$RUN_ID" \
+  --action approve \
+  --decision pass \
+  --reason "All required checks passed."
+```
+
 ## Governance docs
 
 - `CONTRIBUTING.md`


### PR DESCRIPTION
## Summary
- rewrite `COMMAND_REFERENCE.md` into a complete end-user CLI guide covering all implemented command groups
- add explicit aliases, required/optional flags, and copy-paste examples aligned to current parser behavior
- add `knowledge` / `data-export` section as post-CLI-A planned surface with explicit current-state note
- add 3 README workflow playbooks:
  - strategy lifecycle (scan -> create -> backtest -> deploy paper/live)
  - validation lifecycle (trigger -> review -> verdict -> render)
  - shared review lifecycle (invite -> shared-with-me -> comment/decision)

## Validation
- `bun run build`
- `bun test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potential user confusion if examples/flags drift from actual CLI behavior.
> 
> **Overview**
> Rewrites `COMMAND_REFERENCE.md` from a small validation-focused snippet into a **complete end-user command guide** covering all current command groups, with global conventions, aliases, required/optional flags, and examples.
> 
> Adds a **“Workflow playbooks”** section to `README.md` with three end-to-end, copy/paste flows: strategy lifecycle (scan→create→backtest→deploy), validation lifecycle (trigger→review→verdict→render), and shared review lifecycle (invite→shared-with-me→comment/decision).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac96e31259f77babfdaacb75c3f4a6c2525dd6f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR transforms the CLI documentation from minimal reference material into comprehensive end-user guides. `COMMAND_REFERENCE.md` expands from 54 lines to 483 lines, now covering all 12 command groups (research, strategy, backtest, deploy, portfolio, order, dataset, validation/review-run, bot/register/key, shared-validation, invite, conversation) with complete flag documentation and copy-paste examples. `README.md` gains three workflow playbooks demonstrating real-world usage patterns: strategy lifecycle (scan → create → backtest → deploy), validation lifecycle (trigger → review → verdict → render), and shared review lifecycle (invite → shared-with-me → comment/decision). Examples consistently use placeholder IDs with inline replacement comments (`STRATEGY_ID="strat-001" # replace with your strategy id`), making the playbooks immediately actionable. The documentation properly notes planned `knowledge` and `data-export` command groups as post-CLI-A additions with interim workarounds.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - documentation-only changes with no code modifications
- Documentation-only PR with comprehensive, well-structured content. Examples are consistent across files, formatting is correct, and workflow playbooks provide clear end-user guidance. No code logic changes, no dependencies affected, and PR description confirms successful `bun run build` and `bun test` validation
- No files require special attention - both documentation files are well-formatted and internally consistent

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| COMMAND_REFERENCE.md | Complete rewrite transforming minimal reference into comprehensive CLI guide with all command groups, flags, and practical examples |
| README.md | Added three detailed workflow playbooks demonstrating end-to-end CLI usage patterns for strategy, validation, and shared review lifecycles |

</details>


</details>


<sub>Last reviewed commit: ac96e31</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->