### PR TITLE
docs: fix command-reference parity for knowledge/export

### DIFF
--- a/COMMAND_REFERENCE.md
+++ b/COMMAND_REFERENCE.md
@@ -93,6 +93,16 @@ Example:
 trading-cli knowledge search --query "momentum breakout" --assets btc,eth --limit 10
 trading-cli knowledge patterns --type momentum --asset btc --limit 20
 trading-cli knowledge regime --asset btc
+
+cat > /tmp/knowledge-search.json <<'JSON'
+{
+  "query": "range breakout",
+  "assets": ["btc", "eth"],
+  "limit": 5
+}
+JSON
+
+trading-cli knowledge search --input /tmp/knowledge-search.json
 ```
 
 ### strategy
@@ -167,6 +177,15 @@ trading-cli backtest create \
 
 trading-cli backtest export create --dataset-ids dataset-btc-1h-2025 --asset-classes crypto
 trading-cli backtest export get --export-id export-001
+
+cat > /tmp/backtest-export.json <<'JSON'
+{
+  "datasetIds": ["dataset-btc-1h-2025", "dataset-eth-1h-2025"],
+  "assetClasses": ["crypto"]
+}
+JSON
+
+trading-cli backtest export create --input /tmp/backtest-export.json
 ```
 
 ### deploy
@@ -563,20 +582,11 @@ trading-cli conversation session get --session-id session-001
 trading-cli conversation turn create --session-id session-001 --role user --message "hello"
 ```
 
-## After CLI-A: knowledge / data-export
+## Knowledge and Export Status
 
-The generated SDK already contains `KnowledgeApi` and `DataApi` operations, but this CLI build does not expose command groups for them yet.
-
-Current behavior:
-```bash
-trading-cli knowledge
-trading-cli data-export
-# Both currently fail with: Unknown command ...
-```
-
-Interim guidance:
-- Use `research scan --version v2` for embedded `knowledgeEvidence` in scan output.
-- Use existing `backtest get` / `review-run retrieve --raw` artifacts until `data-export` commands are added.
+- `knowledge` command group is exposed and supported (`search`, `patterns`, `regime`).
+- Backtest data export is exposed under `backtest export create|get`.
+- There is currently no top-level `data-export` command group; use `backtest export` commands for data export workflows.
 
 ## Output and Errors
 


### PR DESCRIPTION
## Summary
- remove stale contradiction in `COMMAND_REFERENCE.md` that claimed `knowledge` and export commands were not exposed
- keep docs aligned with current merged CLI behavior:
  - `knowledge search|patterns|regime` are exposed
  - backtest export flow is exposed via `backtest export create|get`
- add copy-paste examples for:
  - `knowledge search --input <file>`
  - `backtest export create --input <file>`
- clarify current export surface: no top-level `data-export` command group, use `backtest export` commands

Fixes #41

## Validation
- `bun install --frozen-lockfile`
- `bun run build`
- `bun test`
- `npm pack --dry-run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that clarify CLI command availability and add examples; no runtime logic or API behavior is modified.
> 
> **Overview**
> Updates `COMMAND_REFERENCE.md` to remove outdated guidance claiming `knowledge`/export commands aren’t exposed, and replaces it with a clear *Knowledge and Export Status* section reflecting current behavior.
> 
> Adds copy-paste JSON file examples for `knowledge search --input` and `backtest export create --input`, and clarifies that exports are done via `backtest export` (no top-level `data-export` group).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a83c37ab2a792e4ab726e4654bedde3cf5d5879f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes outdated "After CLI-A" section that incorrectly claimed `knowledge` and `data-export` commands were not exposed, replacing it with an accurate "Knowledge and Export Status" section that documents current CLI behavior.

- Adds copy-paste JSON file examples for `knowledge search --input` and `backtest export create --input` commands
- JSON field names verified against generated TypeScript interfaces (`datasetIds`, `assetClasses`, `query`, `assets`, `limit`)
- Clarifies that backtest data export uses `backtest export` commands, not a separate top-level `data-export` group
- All changes align documentation with merged CLI functionality

<h3>Confidence Score: 5/5</h3>

- Safe to merge - documentation-only changes with no runtime impact
- Documentation update removes outdated information and adds accurate examples verified against codebase schemas; no code logic or API behavior modified
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| COMMAND_REFERENCE.md | Removes outdated claims about unavailable commands and adds accurate status documentation with verified JSON examples |

</details>


</details>


<sub>Last reviewed commit: a83c37a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->