### PR TITLE
chore(release): bump trading-cli to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `trading-cli` will be documented in this file.
 
+## v0.1.2
+
+- Add CLI parity commands for health, dataset quality, knowledge search/list/regime, backtest export create/get.
+- Add CLI parity commands for validation shared/advanced flows (bots list, runs list, review submit/comment/decision, baseline, replay regression).
+- Complete command reference/playbooks and resolve parity review follow-ups (#41, #42).
+- Lazy-initialize backtest export client path to remove remaining review thread concern.
+
 ## v0.1.1
 
 - Migrate release workflow to npm Trusted Publishing via OIDC (no token required).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trading-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "description": "Trade Nexus external CLI constrained to Platform API boundary",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to 0.1.2
- add changelog entry for parity/docs fixes now merged on main

## Validation
- bun install --frozen-lockfile
- bun run release:check -- --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml

## Next
- merge this PR
- push tag v0.1.2 to trigger OIDC publish

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates version metadata and changelog, with no runtime/code-path changes in this PR.
> 
> **Overview**
> Bumps `trading-cli` package version from `0.1.1` to `0.1.2`.
> 
> Adds a `v0.1.2` entry to `CHANGELOG.md` documenting newly added CLI parity commands, validation flow commands, documentation/playbook updates, and a backtest export client lazy-init tweak (already merged elsewhere).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1e180b41196e372917d55964f07f1b588b0be1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a pure release bookkeeping PR that bumps the `trading-cli` package version from `0.1.1` to `0.1.2` and prepends the corresponding `CHANGELOG.md` entry documenting features already merged into `main`. No runtime code, tests, or configuration files are changed.

- `package.json`: `version` field updated from `"0.1.1"` to `"0.1.2"`; all other fields are untouched.
- `CHANGELOG.md`: New `## v0.1.2` section added at the top, following the existing format, with four bullet points covering CLI parity commands, validation flow commands, docs/playbook updates (referencing `#41`, `#42`), and the lazy-init backtest export client tweak.
- `bun.lock` is correctly left unchanged — the lockfile tracks dependency resolutions, not the package's own version, so `bun install --frozen-lockfile` should continue to pass.
- No issues found; the changelog format is consistent with prior `v0.1.0` and `v0.1.1` entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only version metadata and changelog text with zero runtime impact.
- Both changed files are metadata-only (version string in `package.json` and prose in `CHANGELOG.md`). No source code, dependencies, tests, or CI configuration are modified. The lockfile is correctly untouched. The changelog format and version increment are consistent with prior releases.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version field bumped from `0.1.1` to `0.1.2`; all other fields unchanged and consistent with the rest of the project. |
| CHANGELOG.md | New `v0.1.2` section prepended at the top following the existing format; four bullet-point entries document CLI parity commands, validation flows, docs/playbooks, and the lazy-init backtest export fix. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #45: chore release bump] --> B[package.json\nversion: 0.1.1 → 0.1.2]
    A --> C[CHANGELOG.md\nAdd v0.1.2 entry]
    C --> D[CLI parity commands\nhealth, dataset quality,\nknowledge, backtest export]
    C --> E[Validation flow commands\nbots list, runs list,\nreview submit/comment/decision]
    C --> F[Docs & playbooks\nPR #41, #42 follow-ups]
    C --> G[Lazy-init backtest\nexport client path]
    B --> H[Merge & push tag v0.1.2]
    H --> I[OIDC publish to npm]
```

<sub>Last reviewed commit: c1e180b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->