### PR TITLE
docs(auth): add CLI authentication quickstart + troubleshooting

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,106 @@
+# Authenticate CLI
+
+Quickstart and troubleshooting guide for `trading-cli` authentication.
+
+## Quickstart
+
+1. Install and build:
+
+```bash
+bun install
+bun run build
+```
+
+2. Set the Platform API host:
+
+```bash
+export PLATFORM_API_BASE_URL="https://api-nexus.lona.agency"
+```
+
+3. Login (human auth with bearer token):
+
+```bash
+export PLATFORM_API_BEARER_TOKEN="<jwt-access-token>"
+trading-cli health get
+```
+
+4. Who am I (verify authenticated owner scope):
+
+```bash
+trading-cli bot list
+```
+
+5. Logout:
+
+```bash
+unset PLATFORM_API_BEARER_TOKEN PLATFORM_API_TOKEN PLATFORM_API_KEY
+```
+
+Notes:
+- `PLATFORM_API_BEARER_TOKEN` is preferred.
+- `PLATFORM_API_TOKEN` is accepted as a backward-compatible bearer alias.
+- `PLATFORM_API_KEY` is for runtime bot auth keys (`tnx.bot.<botId>.<keyId>.<secret>`).
+
+## Bot vs Human Auth
+
+| Scenario | Recommended credential | CLI env var | Identity behavior |
+| --- | --- | --- | --- |
+| Human operator running manual commands | JWT bearer token | `PLATFORM_API_BEARER_TOKEN` | Request runs as user identity (`actor_type=user`). |
+| Automation bot calling validation/shared flows | Runtime bot key | `PLATFORM_API_KEY` | Request runs as bot actor while retaining owner scope (`actor_type=bot`, owner user preserved). |
+| Mixed headers present (JWT + bot key) | JWT bearer token | `PLATFORM_API_BEARER_TOKEN` | Verified user identity remains canonical on mixed requests. |
+
+## Troubleshooting
+
+### Expired Token
+
+Symptom:
+- CLI returns `httpStatus: 401` with `code: "AUTH_UNAUTHORIZED"`.
+
+Fix:
+1. Issue a fresh JWT token from your identity provider.
+2. Re-export `PLATFORM_API_BEARER_TOKEN`.
+3. Re-run a low-risk probe:
+
+```bash
+trading-cli health get
+```
+
+### Revoked Token (Runtime Bot Key)
+
+Symptom:
+- CLI returns `httpStatus: 401` with `code: "BOT_API_KEY_REVOKED"`.
+
+Fix:
+1. Rotate key for the affected bot:
+
+```bash
+trading-cli key rotate --bot-id <bot-id> --reason "replace revoked key"
+```
+
+2. Update automation secret storage with the newly issued key.
+3. Retry with the new `PLATFORM_API_KEY`.
+
+### Unauthorized (Missing/Invalid Credentials)
+
+Symptom:
+- CLI returns `httpStatus: 401` with `code: "AUTH_UNAUTHORIZED"` or `code: "BOT_API_KEY_INVALID"`.
+
+Fix:
+1. Confirm one credential is set:
+
+```bash
+env | rg '^PLATFORM_API_(BEARER_TOKEN|TOKEN|KEY)='
+```
+
+2. Ensure `PLATFORM_API_BASE_URL` is `https://api-nexus.lona.agency` or loopback for local dev.
+3. Re-run an authenticated command:
+
+```bash
+trading-cli bot list
+```
+
+## Security Guardrails
+
+- Never commit tokens or keys to source control.
+- Avoid shell history leaks (`HISTCONTROL=ignorespace` and prefix secrets with a space where supported).
+- Revoke compromised bot keys immediately with `trading-cli key revoke`.

--- a/COMMAND_REFERENCE.md
+++ b/COMMAND_REFERENCE.md
@@ -22,6 +22,21 @@ Notes:
 - `PLATFORM_API_BASE_URL` must point to `api-nexus.lona.agency` (or local loopback hosts like `http://localhost:3000`).
 - Provider hosts are blocked by CLI boundary checks.
 - `register invite` and `register partner` can run without an auth token.
+- Detailed auth guide: `AUTHENTICATION.md`.
+
+Auth session examples:
+
+```bash
+# login (human token)
+export PLATFORM_API_BEARER_TOKEN="<jwt-access-token>"
+trading-cli health get
+
+# whoami (owner scope check)
+trading-cli bot list
+
+# logout
+unset PLATFORM_API_BEARER_TOKEN PLATFORM_API_TOKEN PLATFORM_API_KEY
+```
 
 ## Global Conventions
 

--- a/README.md
+++ b/README.md
@@ -221,5 +221,6 @@ trading-cli shared-validation review-decision \
 - `SECURITY.md`
 - `AGENTS.md`
 - `COMMAND_REFERENCE.md`
+- `AUTHENTICATION.md`
 - `CONFIGURATION.md`
 - `RELEASE_PROCESS.md`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dist",
     "CHANGELOG.md",
     "README.md",
+    "AUTHENTICATION.md",
     "LICENSE",
     "COMMAND_REFERENCE.md",
     "CONFIGURATION.md"


### PR DESCRIPTION
## Summary
- add `AUTHENTICATION.md` for end-user CLI auth quickstart
- include login/whoami/logout examples using current env-based auth flow
- add bot-vs-human auth decision table
- document expired token, revoked token, and unauthorized troubleshooting paths
- link auth guide from README and command reference

## Validation
- bun install --frozen-lockfile
- bun run ci
- bun run src/cli.ts bot list

## PR Linking
- Parent PR: https://github.com/iamtxena/trade-nexus/pull/365
- Child PR: this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `AUTHENTICATION.md` guide for CLI end-users, covering quickstart login/whoami/logout flows, a bot-vs-human credential decision table, troubleshooting paths for common `401` error codes, and basic secret-handling guardrails. The guide is linked from both `COMMAND_REFERENCE.md` and `README.md`, and included in the npm `files` manifest in `package.json`.

Key observations:
- The documentation is well-structured and accurately reflects the env-var-based auth flow already documented in `COMMAND_REFERENCE.md`.
- The `rg` (ripgrep) command used in the credential-check diagnostic snippet is not a standard utility and may not be available on all user systems — `grep -E` is a safer, POSIX-portable alternative.
- The shell-history security tip (`HISTCONTROL=ignorespace`) is bash-specific and will silently have no effect for zsh users (the macOS default shell); the guide should mention the zsh equivalent (`setopt histignorespace`).
- The "Who am I" quickstart step uses `trading-cli bot list` as a session-verification probe, which returns an empty list for new users with no registered bots — this may cause unnecessary confusion about whether authentication succeeded.

<h3>Confidence Score: 5/5</h3>

- Documentation-only PR with no runtime code changes; safe to merge.
- All changes are confined to Markdown documentation files and a single `package.json` `files` entry. No CLI logic, authentication code, or tests are modified. The identified issues are minor documentation improvements (portability of a shell snippet, bash-vs-zsh security tip, and a potentially confusing whoami step) that do not block correctness or security of the CLI itself.
- AUTHENTICATION.md — three minor style/usability improvements noted in inline comments.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AUTHENTICATION.md | New authentication guide covering quickstart, bot vs human auth decision table, troubleshooting (expired token, revoked bot key, missing credentials), and security guardrails. Minor issues: `rg` used in a diagnostic command (not universally available), `HISTCONTROL` advice is bash-only, and the "whoami" proxy step using `bot list` may confuse new users with empty bot registries. |
| COMMAND_REFERENCE.md | Adds a link to `AUTHENTICATION.md` and a concise auth session example block (login/whoami/logout). Changes are consistent with existing content and correctly mirror the auth guide. |
| README.md | Adds `AUTHENTICATION.md` to the governance docs list. Simple one-line addition, no issues. |
| package.json | Adds `AUTHENTICATION.md` to the npm `files` manifest so the new guide is included in published packages. Follows the existing pattern for other documentation files. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User starts CLI session]) --> B{Which credential type?}
    B -- Human operator --> C[Set PLATFORM_API_BEARER_TOKEN\n= JWT from identity provider]
    B -- Automation bot --> D[Set PLATFORM_API_KEY\n= tnx.bot.botId.keyId.secret]
    B -- Both present --> C
    C --> E[Set PLATFORM_API_BASE_URL]
    D --> E
    E --> F[Run command\ne.g. trading-cli health get]
    F --> G{HTTP response}
    G -- 200 OK --> H([Success])
    G -- 401 AUTH_UNAUTHORIZED --> I{Token expired?}
    I -- Yes --> J[Refresh JWT\nRe-export PLATFORM_API_BEARER_TOKEN]
    I -- No --> K[Check env vars\ngrep PLATFORM_API_*]
    J --> F
    K --> F
    G -- 401 BOT_API_KEY_REVOKED --> L[trading-cli key rotate\n--bot-id botId]
    L --> M[Update secret storage\nwith new PLATFORM_API_KEY]
    M --> F
    G -- 401 BOT_API_KEY_INVALID --> K
    H --> N{Logout needed?}
    N -- Yes --> O[unset PLATFORM_API_BEARER_TOKEN\nPLATFORM_API_TOKEN\nPLATFORM_API_KEY]
    N -- No --> H
```

<sub>Last reviewed commit: 741f2d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->