### PR TITLE
chore(release): bump trading-cli to v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `trading-cli` will be documented in this file.
 
+## v0.1.6
+
+- Fix `#56` strategy/bot help handling so these targeted subcommands print usage with `--help|-h` without requiring auth or a valid Platform API URL:
+  - `strategy list`
+  - `bot list`
+  - `register invite`
+  - `register partner`
+  - `key rotate`
+  - `key revoke`
+- Add deterministic `--limit <int>` support to `strategy list` and align the CLI reference/examples with the shipped behavior.
+
 ## v0.1.5
 
 - Make help-discovery behavior explicit and agent-safe:

--- a/COMMAND_REFERENCE.md
+++ b/COMMAND_REFERENCE.md
@@ -154,8 +154,10 @@ trading-cli strategy get --strategy-id <id> [--request-id <id>] [--output json|t
 
 #### `strategy list`
 ```bash
-trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--request-id <id>] [--output json|table]
+trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--limit <int>] [--request-id <id>] [--output json|table]
 ```
+
+Use `trading-cli strategy list --help` to print targeted usage without requiring auth or a valid Platform API URL.
 
 #### `strategy update`
 ```bash
@@ -474,6 +476,8 @@ Aliases:
 ```bash
 trading-cli bot list [--request-id <id>]
 ```
+
+Use `trading-cli bot list --help` to print targeted usage without requiring auth or a valid Platform API URL.
 
 #### `register invite`
 ```bash

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ trading-cli health get --help
 trading-cli knowledge search --help
 trading-cli knowledge patterns --help
 trading-cli knowledge regime --help
+trading-cli strategy list --help
 trading-cli backtest export --help
 trading-cli dataset quality-report --help
 ```
@@ -115,6 +116,8 @@ trading-cli knowledge search --query "momentum breakout" --assets btc,eth --limi
 trading-cli knowledge patterns --type momentum --asset btc --limit 20
 
 trading-cli knowledge regime --asset btc
+
+trading-cli strategy list --status tested --limit 5
 
 trading-cli backtest export create --dataset-ids dataset-btc-1h-2025 --asset-classes crypto
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trading-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "description": "Trade Nexus external CLI constrained to Platform API boundary",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { runCoreCommand } from "./core-command";
 import { runDatasetCommand } from "./dataset-command";
 import { runSharedCommand } from "./shared-command";
 import { runAuthCommand } from "./auth-command";
+import { hasHelpFlag, isHelpFlag } from "./command-utils";
 
 const BLOCKED_PROVIDER_HOST_HINTS = [
   "lona",
@@ -51,7 +52,7 @@ function isAuthHelpInvocation(args: string[]): boolean {
   }
 
   const authArgs = args.slice(1);
-  if (authArgs[0] === "--help" || authArgs[0] === "-h") {
+  if (isHelpFlag(authArgs[0])) {
     return true;
   }
 
@@ -60,7 +61,57 @@ function isAuthHelpInvocation(args: string[]): boolean {
     return false;
   }
 
-  return authArgs.slice(1).includes("--help") || authArgs.slice(1).includes("-h");
+  return hasHelpFlag(authArgs.slice(1));
+}
+
+function isStrategyHelpInvocation(args: string[]): boolean {
+  if (args[0] !== "strategy") {
+    return false;
+  }
+
+  const subcommand = args[1];
+  if (isHelpFlag(subcommand)) {
+    return true;
+  }
+
+  return (
+    (subcommand === "create" ||
+      subcommand === "get" ||
+      subcommand === "list" ||
+      subcommand === "update") &&
+    hasHelpFlag(args.slice(2))
+  );
+}
+
+function isValidationBotHelpInvocation(args: string[]): boolean {
+  const root = args[0];
+
+  if (root === "register") {
+    return isHelpFlag(args[1]) || hasHelpFlag(args.slice(2));
+  }
+
+  if (root === "key") {
+    return isHelpFlag(args[1]) || hasHelpFlag(args.slice(2));
+  }
+
+  if (root !== "bot") {
+    return false;
+  }
+
+  const mode = args[1];
+  if (isHelpFlag(mode)) {
+    return true;
+  }
+
+  if (mode === "list") {
+    return hasHelpFlag(args.slice(2));
+  }
+
+  if (mode === "register" || mode === "key") {
+    return hasHelpFlag(args.slice(2));
+  }
+
+  return false;
 }
 
 function emitRootUsage(baseUrl: string): void {
@@ -154,7 +205,11 @@ export async function run(argv: string[], fetchImpl: typeof fetch = fetch): Prom
     return 0;
   }
 
-  if (!isAuthHelpInvocation(args)) {
+  if (
+    !isAuthHelpInvocation(args) &&
+    !isStrategyHelpInvocation(args) &&
+    !isValidationBotHelpInvocation(args)
+  ) {
     try {
       assertPlatformApiBaseUrl(baseUrl);
     } catch (error) {

--- a/src/command-utils.ts
+++ b/src/command-utils.ts
@@ -24,6 +24,14 @@ export function nonEmpty(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+export function isHelpFlag(value: string | undefined): boolean {
+  return value === "--help" || value === "-h";
+}
+
+export function hasHelpFlag(values: string[]): boolean {
+  return values.some((value) => isHelpFlag(value));
+}
+
 export function parseJsonFile<T>(path: string, label: string): T {
   try {
     return JSON.parse(readFileSync(path, "utf-8")) as T;

--- a/src/core-command.ts
+++ b/src/core-command.ts
@@ -5,6 +5,7 @@ import {
   deriveIdempotencyKey,
   deriveRequestId,
   formatTable,
+  isHelpFlag,
   nonEmpty,
   parseJsonFile,
   parseOutputMode,
@@ -48,6 +49,7 @@ type TableOutput = {
 
 const CORE_REQUEST_ID_PREFIX = "req-core";
 const CORE_IDEMPOTENCY_KEY_PREFIX = "idem-core";
+const HELP_OPTION = { type: "boolean", short: "h" } as const;
 
 const STRATEGY_STATUSES = new Set<string>(Object.values(StrategyStatus));
 const DEPLOYMENT_STATUSES = new Set<string>(Object.values(DeploymentStatus));
@@ -164,6 +166,46 @@ function emitOutput(
   console.log(lines.join("\n"));
 }
 
+function emitStrategyCreateUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "strategy create",
+    usage: [
+      "trading-cli strategy create --description \"Momentum breakout\" [--name <name>] [--provider <provider>] [--request-id <id>] [--output json|table]",
+      "trading-cli strategy create --input <create-strategy.json> [--request-id <id>] [--output json|table]",
+    ],
+  });
+}
+
+function emitStrategyGetUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "strategy get",
+    usage: ["trading-cli strategy get --strategy-id <id> [--request-id <id>] [--output json|table]"],
+  });
+}
+
+function emitStrategyListUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "strategy list",
+    usage: [
+      "trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--limit <int>] [--request-id <id>] [--output json|table]",
+    ],
+  });
+}
+
+function emitStrategyUpdateUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "strategy update",
+    usage: [
+      "trading-cli strategy update --strategy-id <id> [--name <name>] [--description <text>] [--status draft|testing|tested|deployable|archived|failed] [--tags <csv>] [--request-id <id>] [--output json|table]",
+      "trading-cli strategy update --strategy-id <id> --input <update-strategy.json> [--request-id <id>] [--output json|table]",
+    ],
+  });
+}
+
 function toStrategyTableRow(strategy: Record<string, unknown>): TableRow {
   return {
     id: strategy.id as string,
@@ -247,7 +289,7 @@ function parseMarketScanRequest(values: ParsedValues): MarketScanRequest {
 
 async function runResearchCommand(args: string[], context: CommandContext): Promise<void> {
   const subcommand = args[0];
-  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+  if (!subcommand || isHelpFlag(subcommand)) {
     context.emit({
       status: "ok",
       command: "research",
@@ -323,7 +365,7 @@ async function runResearchCommand(args: string[], context: CommandContext): Prom
 
 async function runKnowledgeCommand(args: string[], context: CommandContext): Promise<void> {
   const subcommand = args[0];
-  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+  if (!subcommand || isHelpFlag(subcommand)) {
     context.emit({
       status: "ok",
       command: "knowledge",
@@ -460,7 +502,7 @@ async function runKnowledgeCommand(args: string[], context: CommandContext): Pro
 
 async function runHealthCommand(args: string[], context: CommandContext): Promise<void> {
   const subcommand = args[0];
-  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+  if (!subcommand || isHelpFlag(subcommand)) {
     context.emit({
       status: "ok",
       command: "health",
@@ -565,7 +607,7 @@ function parseUpdateStrategyRequest(values: ParsedValues): UpdateStrategyRequest
 
 async function runStrategyCommand(args: string[], context: CommandContext): Promise<void> {
   const subcommand = args[0];
-  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+  if (!subcommand || isHelpFlag(subcommand)) {
     context.emit({
       status: "ok",
       command: "strategy",
@@ -580,12 +622,11 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
     return;
   }
 
-  const api = createStrategiesApiClient(context);
-
   if (subcommand === "create") {
     const parsed = parseArgs({
       args: args.slice(1),
       options: {
+        help: HELP_OPTION,
         input: { type: "string" },
         name: { type: "string" },
         description: { type: "string" },
@@ -597,7 +638,13 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
       strict: true,
     });
 
+    if (parsed.values.help) {
+      emitStrategyCreateUsage(context);
+      return;
+    }
+
     const output = parseOutputMode(parsed.values.output);
+    const api = createStrategiesApiClient(context);
     const response = await api.createStrategyV1({
       createStrategyRequest: parseCreateStrategyRequest(parsed.values),
       xRequestId: parseRequestId(parsed.values),
@@ -623,6 +670,7 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
     const parsed = parseArgs({
       args: args.slice(1),
       options: {
+        help: HELP_OPTION,
         "strategy-id": { type: "string" },
         "request-id": { type: "string" },
         output: { type: "string" },
@@ -631,11 +679,17 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
       strict: true,
     });
 
+    if (parsed.values.help) {
+      emitStrategyGetUsage(context);
+      return;
+    }
+
     const strategyId = nonEmpty(parsed.values["strategy-id"]);
     if (!strategyId) {
       throw new Error("--strategy-id is required.");
     }
     const output = parseOutputMode(parsed.values.output);
+    const api = createStrategiesApiClient(context);
     const response = await api.getStrategyV1({
       strategyId,
       xRequestId: parseRequestId(parsed.values),
@@ -661,8 +715,10 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
     const parsed = parseArgs({
       args: args.slice(1),
       options: {
+        help: HELP_OPTION,
         status: { type: "string" },
         cursor: { type: "string" },
+        limit: { type: "string" },
         "request-id": { type: "string" },
         output: { type: "string" },
       },
@@ -670,12 +726,19 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
       strict: true,
     });
 
+    if (parsed.values.help) {
+      emitStrategyListUsage(context);
+      return;
+    }
+
     const output = parseOutputMode(parsed.values.output);
     const status = parseEnumValue<StrategyStatus>(
       parsed.values.status,
       "--status",
       STRATEGY_STATUSES,
     );
+    const limit = parseOptionalPositiveInteger(parsed.values.limit, "--limit");
+    const api = createStrategiesApiClient(context);
 
     const response = await api.listStrategiesV1({
       xRequestId: parseRequestId(parsed.values),
@@ -684,14 +747,30 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
     });
 
     const serial = toSerializable(response) as Record<string, unknown>;
-    const items = (serial.items as Record<string, unknown>[]) ?? [];
+    const responseItems = (serial.items as Record<string, unknown>[]) ?? [];
+    const items = limit === undefined ? responseItems : responseItems.slice(0, limit);
+    const limitApplied = limit !== undefined && responseItems.length > items.length;
+    const nextCursor =
+      limitApplied
+        ? null
+        : (serial.nextCursor as string | null | undefined);
     emitOutput(
       context,
       output,
-      { status: "ok", command: "strategy list", ...serial },
+      {
+        status: "ok",
+        command: "strategy list",
+        ...serial,
+        items,
+        nextCursor,
+        ...(limit !== undefined ? { limit } : {}),
+      },
       {
         title: "strategy list",
-        notes: [`requestId: ${response.requestId}`, `nextCursor: ${response.nextCursor ?? "-"}`],
+        notes: [
+          `requestId: ${response.requestId}`,
+          `nextCursor: ${nextCursor ?? "-"}${limitApplied ? " (client-side limit applied)" : ""}`,
+        ],
         rows: items.map((item) => toStrategyTableRow(item)),
         columns: ["id", "name", "status", "provider", "createdAt"],
       },
@@ -703,6 +782,7 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
     const parsed = parseArgs({
       args: args.slice(1),
       options: {
+        help: HELP_OPTION,
         "strategy-id": { type: "string" },
         input: { type: "string" },
         name: { type: "string" },
@@ -716,12 +796,18 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
       strict: true,
     });
 
+    if (parsed.values.help) {
+      emitStrategyUpdateUsage(context);
+      return;
+    }
+
     const strategyId = nonEmpty(parsed.values["strategy-id"]);
     if (!strategyId) {
       throw new Error("--strategy-id is required.");
     }
 
     const output = parseOutputMode(parsed.values.output);
+    const api = createStrategiesApiClient(context);
     const response = await api.updateStrategyV1({
       strategyId,
       updateStrategyRequest: parseUpdateStrategyRequest(parsed.values),

--- a/src/generated/trade-nexus-sdk/models/ValidationCliScope.ts
+++ b/src/generated/trade-nexus-sdk/models/ValidationCliScope.ts
@@ -19,7 +19,10 @@
  */
 export enum ValidationCliScope {
     ValidationRead = 'validation:read',
-    ValidationWrite = 'validation:write'
+    ValidationWrite = 'validation:write',
+    StrategyRead = 'strategy:read',
+    BacktestRead = 'backtest:read',
+    DeploymentRead = 'deployment:read'
 }
 
 

--- a/src/validation-bot-command.ts
+++ b/src/validation-bot-command.ts
@@ -4,6 +4,7 @@ import {
   type CommandContext,
   deriveIdempotencyKey,
   deriveRequestId,
+  isHelpFlag,
   nonEmpty,
   parseJsonFile,
   toSerializable,
@@ -21,6 +22,7 @@ import {
 type ParsedValues = ReturnType<typeof parseArgs>["values"];
 const VALIDATION_BOT_REQUEST_ID_PREFIX = "req-validation-bot";
 const VALIDATION_BOT_IDEMPOTENCY_KEY_PREFIX = "idem-validation-bot";
+const HELP_OPTION = { type: "boolean", short: "h" } as const;
 
 function parseMetadataObject(raw: string, label: string): Record<string, unknown> {
   let parsed: unknown;
@@ -142,10 +144,65 @@ function summarizeBotSummary(bot: BotSummary) {
   return toSerializable(bot) as Record<string, unknown>;
 }
 
+function emitRegisterInviteUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "register invite",
+    usage: [
+      "trading-cli register invite --invite-code <code> --bot-name <name> [--metadata-json <json>] [--metadata-file <file>] [--request-id <id>] [--idempotency-key <key>]",
+      "trading-cli register invite --input <register-invite.json> [--request-id <id>] [--idempotency-key <key>]",
+      "trading-cli bot register invite --invite-code <code> --bot-name <name> [--metadata-json <json>] [--metadata-file <file>] [--request-id <id>] [--idempotency-key <key>]",
+    ],
+  });
+}
+
+function emitRegisterPartnerUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "register partner",
+    usage: [
+      "trading-cli register partner --partner-key <key> --partner-secret <secret> --owner-email <email> --bot-name <name> [--metadata-json <json>] [--metadata-file <file>] [--request-id <id>] [--idempotency-key <key>]",
+      "trading-cli register partner --input <register-partner.json> [--request-id <id>] [--idempotency-key <key>]",
+      "trading-cli bot register partner --partner-key <key> --partner-secret <secret> --owner-email <email> --bot-name <name> [--metadata-json <json>] [--metadata-file <file>] [--request-id <id>] [--idempotency-key <key>]",
+    ],
+  });
+}
+
+function emitKeyRotateUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "key rotate",
+    usage: [
+      "trading-cli key rotate --bot-id <botId> [--reason <text>] [--request-id <id>] [--idempotency-key <key>]",
+      "trading-cli bot key rotate --bot-id <botId> [--reason <text>] [--request-id <id>] [--idempotency-key <key>]",
+    ],
+  });
+}
+
+function emitKeyRevokeUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "key revoke",
+    usage: [
+      "trading-cli key revoke --bot-id <botId> --key-id <keyId> [--reason <text>] [--request-id <id>] [--idempotency-key <key>]",
+      "trading-cli bot key revoke --bot-id <botId> --key-id <keyId> [--reason <text>] [--request-id <id>] [--idempotency-key <key>]",
+    ],
+  });
+}
+
+function emitBotListUsage(context: CommandContext): void {
+  context.emit({
+    status: "ok",
+    command: "bot list",
+    usage: ["trading-cli bot list [--request-id <id>]"],
+  });
+}
+
 async function runRegisterInviteCommand(args: string[], context: CommandContext): Promise<void> {
   const parsed = parseArgs({
     args,
     options: {
+      help: HELP_OPTION,
       input: { type: "string" },
       "invite-code": { type: "string" },
       "bot-name": { type: "string" },
@@ -157,6 +214,11 @@ async function runRegisterInviteCommand(args: string[], context: CommandContext)
     allowPositionals: false,
     strict: true,
   });
+
+  if (parsed.values.help) {
+    emitRegisterInviteUsage(context);
+    return;
+  }
 
   const payload = parseInviteRegistrationPayload(parsed.values);
   const requestId = deriveRequestId(
@@ -194,6 +256,7 @@ async function runRegisterPartnerCommand(args: string[], context: CommandContext
   const parsed = parseArgs({
     args,
     options: {
+      help: HELP_OPTION,
       input: { type: "string" },
       "partner-key": { type: "string" },
       "partner-secret": { type: "string" },
@@ -207,6 +270,11 @@ async function runRegisterPartnerCommand(args: string[], context: CommandContext
     allowPositionals: false,
     strict: true,
   });
+
+  if (parsed.values.help) {
+    emitRegisterPartnerUsage(context);
+    return;
+  }
 
   const payload = parsePartnerBootstrapPayload(parsed.values);
   const requestId = deriveRequestId(
@@ -244,6 +312,7 @@ async function runRotateKeyCommand(args: string[], context: CommandContext): Pro
   const parsed = parseArgs({
     args,
     options: {
+      help: HELP_OPTION,
       "bot-id": { type: "string" },
       reason: { type: "string" },
       "request-id": { type: "string" },
@@ -252,6 +321,11 @@ async function runRotateKeyCommand(args: string[], context: CommandContext): Pro
     allowPositionals: false,
     strict: true,
   });
+
+  if (parsed.values.help) {
+    emitKeyRotateUsage(context);
+    return;
+  }
 
   const botId = nonEmpty(parsed.values["bot-id"]);
   if (!botId) {
@@ -294,6 +368,7 @@ async function runRevokeKeyCommand(args: string[], context: CommandContext): Pro
   const parsed = parseArgs({
     args,
     options: {
+      help: HELP_OPTION,
       "bot-id": { type: "string" },
       "key-id": { type: "string" },
       reason: { type: "string" },
@@ -303,6 +378,11 @@ async function runRevokeKeyCommand(args: string[], context: CommandContext): Pro
     allowPositionals: false,
     strict: true,
   });
+
+  if (parsed.values.help) {
+    emitKeyRevokeUsage(context);
+    return;
+  }
 
   const botId = nonEmpty(parsed.values["bot-id"]);
   const keyId = nonEmpty(parsed.values["key-id"]);
@@ -347,11 +427,17 @@ async function runListBotsCommand(args: string[], context: CommandContext): Prom
   const parsed = parseArgs({
     args,
     options: {
+      help: HELP_OPTION,
       "request-id": { type: "string" },
     },
     allowPositionals: false,
     strict: true,
   });
+
+  if (parsed.values.help) {
+    emitBotListUsage(context);
+    return;
+  }
 
   const requestId = deriveRequestId(
     VALIDATION_BOT_REQUEST_ID_PREFIX,
@@ -417,14 +503,14 @@ function emitKeyUsage(context: CommandContext): void {
 
 export async function runValidationBotCommand(args: string[], context: CommandContext): Promise<void> {
   const root = args[0];
-  if (!root || root === "--help" || root === "-h") {
+  if (!root || isHelpFlag(root)) {
     emitUsage(context);
     return;
   }
 
   if (root === "register") {
     const mode = args[1];
-    if (mode === "--help" || mode === "-h") {
+    if (isHelpFlag(mode)) {
       emitRegisterUsage(context);
       return;
     }
@@ -444,7 +530,7 @@ export async function runValidationBotCommand(args: string[], context: CommandCo
 
   if (root === "key") {
     const action = args[1];
-    if (action === "--help" || action === "-h") {
+    if (isHelpFlag(action)) {
       emitKeyUsage(context);
       return;
     }

--- a/tests/smoke/core-cli.test.ts
+++ b/tests/smoke/core-cli.test.ts
@@ -383,6 +383,99 @@ describe("core command groups", () => {
     expect(exportPayload?.status).toBe("ok");
   });
 
+  test("strategy list help bypasses boundary validation and emits targeted usage", async () => {
+    const logs: string[] = [];
+    const errors: string[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "https://api.binance.com";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    expect(await run(["bun", "src/cli.ts", "strategy", "list", "--help"])).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "strategy", "list", "-h"])).toBe(0);
+    expect(errors).toEqual([]);
+
+    const payloads = logs.map((line) => JSON.parse(line) as { command?: string; usage?: string[] });
+    expect(payloads[0]?.command).toBe("strategy list");
+    expect(payloads[1]?.command).toBe("strategy list");
+    expect(payloads[0]?.usage?.[0]).toContain("--limit <int>");
+  });
+
+  test("strategy list applies deterministic client-side limit slicing", async () => {
+    const logs: string[] = [];
+    const requests: RecordedRequest[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "http://localhost:3000";
+    process.env.PLATFORM_API_BEARER_TOKEN = "token-core-limit-001";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+
+    const fetchMock = (async (input, init) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      requests.push({ path: url.pathname, method, headers });
+
+      if (url.pathname === "/v1/strategies" && method === "GET") {
+        return jsonResponse({
+          requestId: "req-strategy-list-limit-001",
+          items: [
+            {
+              id: "strat-001",
+              name: "Breakout",
+              status: "tested",
+              provider: "lona",
+              providerRefId: "provider-001",
+              tags: ["momentum"],
+              createdAt: "2026-03-01T10:00:00Z",
+              updatedAt: "2026-03-01T10:00:00Z",
+            },
+            {
+              id: "strat-002",
+              name: "Mean Reversion",
+              status: "draft",
+              provider: "xai",
+              providerRefId: "provider-002",
+              tags: ["mean-reversion"],
+              createdAt: "2026-03-02T10:00:00Z",
+              updatedAt: "2026-03-02T10:00:00Z",
+            },
+          ],
+          nextCursor: "cursor-002",
+        });
+      }
+
+      return jsonResponse(
+        {
+          requestId: "req-unexpected",
+          error: { code: "not_found", message: `Unexpected request: ${method} ${url.pathname}` },
+        },
+        404,
+      );
+    }) as typeof fetch;
+
+    expect(
+      await run(["bun", "src/cli.ts", "strategy", "list", "--limit", "1"], fetchMock),
+    ).toBe(0);
+    expect(requests.map((request) => `${request.method} ${request.path}`)).toEqual(["GET /v1/strategies"]);
+
+    const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+      command?: string;
+      limit?: number;
+      nextCursor?: string | null;
+      items?: Array<{ id: string }>;
+    };
+    expect(payload.command).toBe("strategy list");
+    expect(payload.limit).toBe(1);
+    expect(payload.nextCursor).toBeNull();
+    expect(payload.items?.map((item) => item.id)).toEqual(["strat-001"]);
+  });
+
   test("deploy create sends idempotency header and table output is deterministic", async () => {
     const logs: string[] = [];
     const requests: RecordedRequest[] = [];

--- a/tests/smoke/registration-cli.test.ts
+++ b/tests/smoke/registration-cli.test.ts
@@ -366,6 +366,32 @@ describe("bot registration and key lifecycle commands", () => {
     expect(keyPayload.usage).toContain("trading-cli key rotate --bot-id <botId> [--reason <text>]");
   });
 
+  test("bot/register/key leaf help bypasses boundary validation and emits targeted usage", async () => {
+    const logs: string[] = [];
+    const errors: string[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "https://api.binance.com";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    expect(await run(["bun", "src/cli.ts", "bot", "list", "--help"])).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "register", "invite", "--help"])).toBe(0);
+    expect(await run(["bun", "src/cli.ts", "key", "rotate", "--help"])).toBe(0);
+    expect(errors).toEqual([]);
+
+    const payloads = logs.map((line) => JSON.parse(line) as { command?: string; usage?: string[] });
+    expect(payloads[0]?.command).toBe("bot list");
+    expect(payloads[0]?.usage).toContain("trading-cli bot list [--request-id <id>]");
+    expect(payloads[1]?.command).toBe("register invite");
+    expect(payloads[1]?.usage?.[0]).toContain("trading-cli register invite --invite-code <code>");
+    expect(payloads[2]?.command).toBe("key rotate");
+    expect(payloads[2]?.usage?.[0]).toContain("trading-cli key rotate --bot-id <botId>");
+  });
+
   test("bot list maps to validation bot registry endpoint and emits deterministic json", async () => {
     const logs: string[] = [];
     let authHeader: string | null = null;


### PR DESCRIPTION
## Summary
- bump `trading-cli` to `0.1.6` and add release notes
- resolve #56 strategy/bot help inconsistencies and add deterministic `strategy list --limit` behavior
- refresh the vendored SDK to match the authoritative Platform API spec

## Verification
- `bun install --frozen-lockfile`
- `bun run ci`
- `bun run release:check -- --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml`

Closes #56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI boundary-validation bypass logic and command parsing, which could inadvertently widen when unsafe base URLs are accepted if help detection is wrong. Functional changes are still limited to explicit `--help|-h` paths and client-side result formatting.
> 
> **Overview**
> Bumps the CLI to **v0.1.6** and updates `CHANGELOG.md`, `README.md`, and `COMMAND_REFERENCE.md` to reflect new help/discovery behavior and `strategy list --limit`.
> 
> Fixes `#56` by expanding the CLI’s *help bypass* logic so targeted leaf help (`--help|-h`) for `strategy ...`, `bot list`, `register invite|partner`, and `key rotate|revoke` prints usage without requiring auth or a valid/allowed `PLATFORM_API_BASE_URL`, using shared `isHelpFlag`/`hasHelpFlag` helpers and explicit per-leaf usage emitters.
> 
> Adds deterministic `--limit <int>` to `strategy list` by slicing results client-side and nulling `nextCursor` when the limit truncates the returned page, with new smoke tests covering both help bypass and limit behavior; also refreshes the vendored SDK enum scopes (`ValidationCliScope`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d80c05d06001b6c69d49ff3ff62f0d77886b14a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `trading-cli` to v0.1.6 and delivers two behavioural fixes: (1) a set of targeted subcommands (`strategy list`, `bot list`, `register invite/partner`, `key rotate/revoke`) can now print usage via `--help`/`-h` without requiring a valid Platform API URL or auth token, and (2) `strategy list` gains a `--limit <int>` flag implemented as a client-side slice of the first API page. The vendored SDK's `ValidationCliScope` enum is also refreshed to include three new read scopes matching the updated Platform API spec.

Key changes:
- **`src/command-utils.ts`**: Extracts `isHelpFlag` / `hasHelpFlag` helpers, eliminating repeated inline string comparisons across the codebase.
- **`src/cli.ts`**: Adds `isStrategyHelpInvocation` and `isValidationBotHelpInvocation` pre-flight guards that short-circuit URL validation before routing; the `strategy` guard enumerates exact subcommands while the `register`/`key` guards accept any token in the subcommand position (see inline comment).
- **`src/core-command.ts`**: Each `strategy` subcommand now parses a `help` boolean option and returns targeted usage before any API client is instantiated; `api` creation is deferred past the help check. The new `--limit` logic slices `responseItems.slice(0, limit)` client-side and nulls `nextCursor` only when `responseItems.length > limit` — the equal-to edge case preserves the API cursor (see inline comment).
- **`src/validation-bot-command.ts`**: Mirrors the same help-first pattern for all bot/register/key leaf commands; `HELP_OPTION` is redeclared locally rather than shared from `command-utils`.
- **Tests**: Two new smoke tests cover the help bypass and deterministic limit slicing with a fetch mock.

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge with minor style and consistency concerns; no critical runtime or security issues found.
- The changes are well-scoped, backed by new smoke tests, and the client-side limit behaviour is intentionally documented. The one logic concern (overly broad URL-bypass for unknown `register`/`key` subcommands) degrades gracefully into a clear error message rather than silently misbehaving. The duplicated `HELP_OPTION` constant is cosmetic. No security issues, no data loss paths, and the SDK enum addition is additive-only.
- `src/cli.ts` (subcommand-guard conservatism) and `src/core-command.ts` (`limitApplied` equal-to edge case and `HELP_OPTION` duplication).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/cli.ts | Adds `isStrategyHelpInvocation` and `isValidationBotHelpInvocation` guards to bypass URL/auth validation for help flags; `register`/`key` bypass is broader than `strategy` (accepts unknown subcommands). |
| src/core-command.ts | Adds `--help` short-circuit for all `strategy` subcommands, lazy-initializes `api` after help check, and adds client-side `--limit` slicing for `strategy list`; limit is not forwarded to the API and the `limitApplied` boundary condition (equal-to case) silently preserves `nextCursor`. |
| src/command-utils.ts | Extracts `isHelpFlag` and `hasHelpFlag` helpers; clean and well-typed addition with no issues. |
| src/validation-bot-command.ts | Adds `--help` short-circuits for all `register`, `key`, and `bot list` leaf commands; `HELP_OPTION` constant is duplicated from `core-command.ts` rather than shared via `command-utils`. |
| src/generated/trade-nexus-sdk/models/ValidationCliScope.ts | Adds three new enum members (`strategy:read`, `backtest:read`, `deployment:read`) to align with updated Platform API spec; straightforward generated-file update. |
| tests/smoke/core-cli.test.ts | Adds two well-structured smoke tests: one verifying help bypass with an invalid base URL, and one verifying deterministic client-side limit slicing with a fetch mock. |
| tests/smoke/registration-cli.test.ts | Adds smoke test confirming `bot list --help`, `register invite --help`, and `key rotate --help` all bypass URL validation and emit correct targeted usage; good coverage of the new bypass paths. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI invoked: run argv] --> B{isRootHelpInvocation?}
    B -- Yes --> C[emitRootUsage → exit 0]
    B -- No --> D{isAuthHelpInvocation OR\nisStrategyHelpInvocation OR\nisValidationBotHelpInvocation?}
    D -- Yes --> E[Skip assertPlatformApiBaseUrl]
    D -- No --> F[assertPlatformApiBaseUrl\nthrow if invalid/blocked]
    F -- Error --> G[emitError → exit 1]
    E --> H[Route to command handler]
    F -- OK --> H

    H --> I{args0}
    I -- register / key --> J[runValidationBotCommand args]
    I -- bot --> K[runValidationBotCommand args.slice 1]
    I -- strategy --> L[runCoreCommand args]
    I -- auth --> M[runAuthCommand args.slice 1]

    J --> N{root = register / key}
    N -- register invite/partner --> O{parsed.values.help?}
    O -- Yes --> P[emitRegisterInviteUsage\nor emitRegisterPartnerUsage]
    O -- No --> Q[Execute API call]

    K --> R{mode = list/register/key}
    R -- list --> S{parsed.values.help?}
    S -- Yes --> T[emitBotListUsage]
    S -- No --> U[Execute bot list API]

    L --> V{subcommand}
    V -- list --> W{parsed.values.help?}
    W -- Yes --> X[emitStrategyListUsage]
    W -- No --> Y[listStrategiesV1\nno limit param]
    Y --> Z[client-side slice\nif --limit provided]
    Z --> AA{responseItems.length\n> limit?}
    AA -- Yes --> AB[limitApplied=true\nnextCursor=null]
    AA -- No --> AC[limitApplied=false\nnextCursor=API cursor]
```

<sub>Last reviewed commit: 6d80c05</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->