### PR TITLE
chore(release): bump trading-cli to v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `trading-cli` will be documented in this file.
 
+## v0.1.7
+
+- Publish the GA candidate from current `main` so npm latest includes the merged CLI help/limit fixes from `#57`:
+  - targeted `strategy list --help` and `bot list --help` keep working without auth or boundary failures
+  - `bot list --limit` returns the deterministic unsupported-option guidance instead of a parser-only error
+- Follow up on merged review feedback by surfacing `--limit` in parent `strategy --help` output and consolidating shared help parsing helpers across CLI command modules.
+
 ## v0.1.6
 
 - Fix `#56` strategy/bot help handling so these targeted subcommands print usage with `--help|-h` without requiring auth or a valid Platform API URL:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trading-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "description": "Trade Nexus external CLI constrained to Platform API boundary",
   "repository": {

--- a/src/auth-command.ts
+++ b/src/auth-command.ts
@@ -1,7 +1,7 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import { parseArgs } from "node:util";
 
-import { type CommandContext, deriveRequestId, nonEmpty } from "./command-utils";
+import { type CommandContext, deriveRequestId, hasHelpFlag, nonEmpty } from "./command-utils";
 import {
   clearStoredCliCredential,
   loadStoredCliCredential,
@@ -124,10 +124,6 @@ function emitAuthUsage(context: CommandContext): void {
       "trading-cli auth logout",
     ],
   });
-}
-
-function hasHelpFlag(args: string[]): boolean {
-  return args.includes("--help") || args.includes("-h");
 }
 
 function emitAuthLoginUsage(context: CommandContext): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,7 @@ function isValidationBotHelpInvocation(args: string[]): boolean {
   const root = args[0];
 
   if (root === "register") {
+    // Keep validation-bot help parsing local so dispatcher errors do not depend on API URL state.
     return isHelpFlag(args[1]) || hasHelpFlag(args.slice(2));
   }
 

--- a/src/command-utils.ts
+++ b/src/command-utils.ts
@@ -32,6 +32,8 @@ export function hasHelpFlag(values: string[]): boolean {
   return values.some((value) => isHelpFlag(value));
 }
 
+export const HELP_OPTION = { type: "boolean", short: "h" } as const;
+
 export function parseJsonFile<T>(path: string, label: string): T {
   try {
     return JSON.parse(readFileSync(path, "utf-8")) as T;

--- a/src/core-command.ts
+++ b/src/core-command.ts
@@ -5,6 +5,7 @@ import {
   deriveIdempotencyKey,
   deriveRequestId,
   formatTable,
+  HELP_OPTION,
   isHelpFlag,
   nonEmpty,
   parseJsonFile,
@@ -49,7 +50,6 @@ type TableOutput = {
 
 const CORE_REQUEST_ID_PREFIX = "req-core";
 const CORE_IDEMPOTENCY_KEY_PREFIX = "idem-core";
-const HELP_OPTION = { type: "boolean", short: "h" } as const;
 
 const STRATEGY_STATUSES = new Set<string>(Object.values(StrategyStatus));
 const DEPLOYMENT_STATUSES = new Set<string>(Object.values(DeploymentStatus));
@@ -615,7 +615,7 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
         "trading-cli strategy create --description \"Momentum breakout\" [--name <name>] [--output json|table]",
         "trading-cli strategy create --input <create-strategy.json> [--output json|table]",
         "trading-cli strategy get --strategy-id <id> [--output json|table]",
-        "trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--output json|table]",
+        "trading-cli strategy list [--status draft|testing|tested|deployable|archived|failed] [--cursor <token>] [--limit <int>] [--output json|table]",
         "trading-cli strategy update --strategy-id <id> --status deployable [--output json|table]",
       ],
     });
@@ -750,6 +750,7 @@ async function runStrategyCommand(args: string[], context: CommandContext): Prom
     const responseItems = (serial.items as Record<string, unknown>[]) ?? [];
     const items = limit === undefined ? responseItems : responseItems.slice(0, limit);
     const limitApplied = limit !== undefined && responseItems.length > items.length;
+    // Preserve the server cursor when the first page already fits within the caller's limit.
     const nextCursor =
       limitApplied
         ? null

--- a/src/validation-bot-command.ts
+++ b/src/validation-bot-command.ts
@@ -4,6 +4,8 @@ import {
   type CommandContext,
   deriveIdempotencyKey,
   deriveRequestId,
+  HELP_OPTION,
+  hasHelpFlag,
   isHelpFlag,
   nonEmpty,
   parseJsonFile,
@@ -22,11 +24,6 @@ import {
 type ParsedValues = ReturnType<typeof parseArgs>["values"];
 const VALIDATION_BOT_REQUEST_ID_PREFIX = "req-validation-bot";
 const VALIDATION_BOT_IDEMPOTENCY_KEY_PREFIX = "idem-validation-bot";
-const HELP_OPTION = { type: "boolean", short: "h" } as const;
-
-function hasHelpFlag(args: string[]): boolean {
-  return args.includes("--help") || args.includes("-h");
-}
 
 function hasLimitFlag(args: string[]): boolean {
   return args.some((arg) => arg === "--limit" || arg.startsWith("--limit="));
@@ -433,11 +430,7 @@ async function runRevokeKeyCommand(args: string[], context: CommandContext): Pro
 
 async function runListBotsCommand(args: string[], context: CommandContext): Promise<void> {
   if (hasHelpFlag(args)) {
-    context.emit({
-      status: "ok",
-      command: "bot list",
-      usage: ["trading-cli bot list [--request-id <id>]"],
-    });
+    emitBotListUsage(context);
     return;
   }
 
@@ -448,17 +441,11 @@ async function runListBotsCommand(args: string[], context: CommandContext): Prom
   const parsed = parseArgs({
     args,
     options: {
-      help: HELP_OPTION,
       "request-id": { type: "string" },
     },
     allowPositionals: false,
     strict: true,
   });
-
-  if (parsed.values.help) {
-    emitBotListUsage(context);
-    return;
-  }
 
   const requestId = deriveRequestId(
     VALIDATION_BOT_REQUEST_ID_PREFIX,

--- a/tests/smoke/core-cli.test.ts
+++ b/tests/smoke/core-cli.test.ts
@@ -405,6 +405,28 @@ describe("core command groups", () => {
     expect(payloads[0]?.usage?.[0]).toContain("--limit <int>");
   });
 
+  test("strategy parent help advertises the list limit flag", async () => {
+    const logs: string[] = [];
+    const errors: string[] = [];
+
+    process.env.PLATFORM_API_BASE_URL = "https://api.binance.com";
+    console.log = (value: unknown) => {
+      logs.push(String(value));
+    };
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    expect(await run(["bun", "src/cli.ts", "strategy", "--help"])).toBe(0);
+    expect(errors).toEqual([]);
+
+    const payload = JSON.parse(logs.at(-1) ?? "{}") as { command?: string; usage?: string[] };
+    expect(payload.command).toBe("strategy");
+    expect(
+      payload.usage?.some((line) => line.includes("trading-cli strategy list") && line.includes("--limit <int>")),
+    ).toBe(true);
+  });
+
   test("strategy get help bypasses boundary validation and emits targeted usage", async () => {
     const logs: string[] = [];
     const errors: string[] = [];

--- a/tests/smoke/registration-cli.test.ts
+++ b/tests/smoke/registration-cli.test.ts
@@ -392,6 +392,27 @@ describe("bot registration and key lifecycle commands", () => {
     expect(payloads[2]?.usage?.[0]).toContain("trading-cli key rotate --bot-id <botId>");
   });
 
+  test("invalid register/key help still returns dispatcher guidance before boundary validation", async () => {
+    const errors: string[] = [];
+    const fetchMock = (async () => {
+      throw new Error("fetch should not be called");
+    }) as unknown as typeof fetch;
+
+    process.env.PLATFORM_API_BASE_URL = "https://api.binance.com";
+    console.error = (value: unknown) => {
+      errors.push(String(value));
+    };
+
+    expect(
+      await run(["bun", "src/cli.ts", "register", "totally-invalid", "--help"], fetchMock),
+    ).toBe(1);
+    expect(await run(["bun", "src/cli.ts", "key", "totally-invalid", "--help"], fetchMock)).toBe(1);
+
+    const payloads = errors.map((line) => JSON.parse(line) as { message?: string });
+    expect(payloads[0]?.message).toBe("Unknown register mode 'totally-invalid'. Use 'invite' or 'partner'.");
+    expect(payloads[1]?.message).toBe("Unknown key action 'totally-invalid'. Use 'rotate' or 'revoke'.");
+  });
+
   test("bot list maps to validation bot registry endpoint and emits deterministic json", async () => {
     const logs: string[] = [];
     let authHeader: string | null = null;


### PR DESCRIPTION
## Summary
- bump trading-cli from 0.1.6 to 0.1.7 and add the release changelog entry
- fold in the small follow-up fixes needed to close the remaining #57/#58 review threads
- add smoke coverage for parent strategy help and invalid register/key help dispatcher behavior

## Verification
- bun install --frozen-lockfile
- bun test
- bun run release:check -- --spec /Users/txena/sandbox/16.enjoy/trading/trade-nexus/docs/architecture/specs/platform-api.openapi.yaml

Refs #59

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI argument parsing/dispatch and help/boundary-bypass behavior, which can subtly change user-facing command handling; changes are small and covered by new smoke tests.
> 
> **Overview**
> Bumps `trading-cli` to **v0.1.7** and adds the corresponding changelog entry.
> 
> Improves CLI help/flag handling by centralizing `--help|-h` parsing helpers (`HELP_OPTION`, `hasHelpFlag`) and adjusting dispatch/bypass logic so `strategy --help` now advertises `--limit`, `bot list --help` is handled consistently without parser-side help, and invalid `register`/`key` subcommand help still returns dispatcher guidance before boundary validation.
> 
> Adds smoke tests covering parent `strategy` help output and the invalid `register`/`key` help error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83661f39653f5f2ef441aee01c6a48293325bb7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `trading-cli` from v0.1.6 to v0.1.7 and delivers a small set of follow-up polish items from the previous `#57`/`#58` review cycle: it consolidates the duplicated `HELP_OPTION` constant and `hasHelpFlag` helper into `command-utils.ts` (previously copied verbatim in `core-command.ts`, `validation-bot-command.ts`, and `auth-command.ts`), surfaces `--limit <int>` in the parent `strategy --help` usage string so the flag is discoverable without running a sub-command, and reworks `runListBotsCommand` to guard on `hasHelpFlag` before calling `parseArgs` (avoiding the need to register `--help` as a known option in strict-mode parsing). Two new smoke tests are added to lock in the fixed behaviours.

**Key changes:**
- `command-utils.ts` — new exported `HELP_OPTION` const; `hasHelpFlag` was already exported.
- `core-command.ts` / `validation-bot-command.ts` / `auth-command.ts` — remove local duplicates of `HELP_OPTION` / `hasHelpFlag`, import from shared module.
- `core-command.ts` — `strategy list` usage string now includes `[--limit <int>]` in the parent help output.
- `validation-bot-command.ts` — `runListBotsCommand` checks help eagerly before `parseArgs`; removes the `help` option from the `parseArgs` options object (harmless because the early guard intercepts it first; also makes `strict: true` parseable without registering a flag that will never reach parsing).
- `tests/smoke/core-cli.test.ts` — smoke test for strategy parent help advertising `--limit`.
- `tests/smoke/registration-cli.test.ts` — smoke test confirming invalid register/key sub-commands with `--help` return the dispatcher error rather than a boundary-URL error.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure refactoring/polish release with no behavioral regressions and new smoke-test coverage locking in the fixed paths.
- All changes are either mechanical deduplication of constants/helpers (no logic change) or documentation of the `--limit` flag in help text. The one meaningful logic tweak — moving the `hasHelpFlag` guard before `parseArgs` in `runListBotsCommand` — is functionally equivalent to the previous double-check pattern and is now more lenient in the right direction (shows help even when other unknown flags are present). Two new smoke tests increase confidence in the boundary-bypass and usage-string correctness. No new dependencies, no schema changes, no async-flow changes.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["run(argv)"] --> B{Root help?}
    B -- yes --> C[emitRootUsage\nexit 0]
    B -- no --> D{Auth/Strategy/\nValidationBot help?}
    D -- no --> E[assertPlatformApiBaseUrl\nboundary check]
    E -- fail --> F[emitError\nexit 1]
    E -- ok --> G[Route to command handler]
    D -- yes --> G
    G --> H{register or key?}
    H --> I[runValidationBotCommand]
    I --> J{Valid subcommand?}
    J -- invalid --> K[throw dispatcher error\nemitError\nexit 1]
    J -- valid --> L[runRegister or runKey\ncommand]
    G --> M{bot list?}
    M -- yes --> N{hasHelpFlag\nearly check}
    N -- yes --> O[emitBotListUsage\nexit 0]
    N -- no --> P[parseArgs strict=true\nno help option registered]
    P --> Q[Call list bots API]
    G --> R{strategy?}
    R -- help flag --> S[emitStrategyUsage\nincl. limit in list line\nexit 0]
    R -- subcommand --> T[runStrategy subcommand]
```

<sub>Last reviewed commit: 83661f3</sub>

<!-- /greptile_comment -->